### PR TITLE
Fix build-pregen.sh

### DIFF
--- a/build-pregen.sh
+++ b/build-pregen.sh
@@ -4,5 +4,5 @@
 docker pull btcpayserver/docker-compose-generator
 docker run -v "$(pwd)/Production:/app/Production" \
            -v "$(pwd)/Production-NoReverseProxy:/app/Production-NoReverseProxy" \
-           -v "$(pwd)/docker-compose-generator/docker-fragments:/app/docker-fragments" \ 
+           -v "$(pwd)/docker-compose-generator/docker-fragments:/app/docker-fragments" \
            --rm btcpayserver/docker-compose-generator pregen


### PR DESCRIPTION
The bash script failed because of the extra space at the end:

> MacBook-Pro-4:btcpayserver-docker lucas$ ./build-pregen.sh
> Using default tag: latest
> latest: Pulling from btcpayserver/docker-compose-generator
> ff3a5c916c92: Pull complete
> 027780d5a669: Pull complete
> 003c9c0fa8b1: Pull complete
> 8da3c2b261a3: Pull complete
> 23830abc2bee: Pull complete
> a913f7e16922: Pull complete
> Digest: sha256:09f3a49fa50e97743cb4c68826803aa43f634009016fa67285a094523f39d337
> Status: Downloaded newer image for btcpayserver/docker-compose-generator:latest
> docker: invalid reference format.
> See 'docker run --help'.
> ./build-pregen.sh: line 8: --rm: command not found
> 