### PR TITLE
Add FTC to docker-compose-generator

### DIFF
--- a/docker-compose-generator/src/Properties/launchSettings.json
+++ b/docker-compose-generator/src/Properties/launchSettings.json
@@ -5,6 +5,7 @@
       "commandLineArgs": "pregen",
       "environmentVariables": {
         "BTCPAYGEN_LIGHTNING": "clightning",
+        "BTCPAYGEN_CRYPTO4": "ftc",
         "BTCPAYGEN_CRYPTO3": "btg",
         "BTCPAYGEN_CRYPTO2": "ltc",
         "BTCPAYGEN_CRYPTO1": "btc",


### PR DESCRIPTION
If you could re-run the docker-compose-generator it would add FTC as one of the options for btcpay-setup.sh (like BTG is), as far as I understand the setup.

Thanks for your work. We plan to use BTCPay quite a bit to push merchant adoption for BTC, LTC & FTC in Switzerland and to contribute back whenever possible :)