### PR TITLE
Add btcpay-down tool

### DIFF
--- a/btcpay-down.sh
+++ b/btcpay-down.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. /etc/profile.d/btcpay-env.sh
+
+cd "`dirname $BTCPAY_ENV_FILE`"
+docker-compose -f $BTCPAY_DOCKER_COMPOSE down


### PR DESCRIPTION
For purposes of some monitoring tools that require both start and stop scripts.