### PR TITLE
Create opt-lnd_bitcoin-autopilot.yml

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-lnd_bitcoin-autopilot.yml
+++ b/docker-compose-generator/docker-fragments/opt-lnd_bitcoin-autopilot.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  lnd_bitcoin:
+    environment:
+      # If you don't use Lightning Network, use opt-save-store-xxs instead
+      # This save about 1 years of block, your lightning node won't be able to see channel created 1 year since the time you start it.
+      LND_EXTRA_ARGS: |
+        autopilot.active=1
+        autopilot.maxchannels=5
+        autopilot.allocation=0.6


### PR DESCRIPTION
enable autopilot for bitcoin LND with default settings. please adapt to your needs!

As discussed on SLACK I've used the default LND settings for the autopilot feature. We might want to edit the main Readme.md file of the repo as well to give instructions how to enable this? :-)