### PR TITLE
WIP:new Reverse Proxy: Traefik

### DIFF
--- a/Generated/.gitignore
+++ b/Generated/.gitignore
@@ -1,2 +1,3 @@
 *.yml
 *.tmpl
+*.toml

--- a/Production/traefilk.toml
+++ b/Production/traefilk.toml
@@ -1,0 +1,35 @@
+defaultEntryPoints = ["https","http"]
+
+logLevel="ERROR"
+
+[entryPoints]
+	useXForwardedFor = true
+  [entryPoints.http]
+  address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  [entryPoints.https]
+  address = ":443"
+  [entryPoints.https.tls]
+
+[retry]
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+watch = true
+exposedByDefault = false
+
+[acme]
+storage = "acme.json"
+entryPoint = "https"
+onHostRule = true
+[acme.httpChallenge]
+entryPoint = "http"
+
+[traefikLog]
+  filePath = "/traefik_logs/traefik.log"
+  format   = "json"
+
+[accessLog]
+  filePath = "/traefik_logs/access.log"
+  format = "json"

--- a/build.ps1
+++ b/build.ps1
@@ -21,3 +21,7 @@ docker run -v "$(Get-Location)\Generated:/app/Generated" `
 If ($BTCPAYGEN_REVERSEPROXY -eq "nginx") {
     Copy-Item ".\Production\nginx.tmpl" -Destination ".\Generated"
 }
+
+If ($BTCPAYGEN_REVERSEPROXY -eq "traefik") {
+    Copy-Item ".\Production\traefik.toml" -Destination ".\Generated"
+}

--- a/build.sh
+++ b/build.sh
@@ -22,3 +22,11 @@ docker run -v "$(pwd)/Generated:/app/Generated" \
 if [ "$BTCPAYGEN_REVERSEPROXY" == "nginx" ]; then
     cp Production/nginx.tmpl Generated/nginx.tmpl
 fi
+
+if [ "$BTCPAYGEN_REVERSEPROXY" == "traefik" ]; then
+    cp Production/traefik.toml Generated/traefik.toml
+fi
+
+
+
+

--- a/docker-compose-generator/docker-fragments/traefik-labels.yml
+++ b/docker-compose-generator/docker-fragments/traefik-labels.yml
@@ -8,3 +8,5 @@ services:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:${BTCPAY_HOST}"
       - "traefik.port.rule=49392"
+      - "traefik.acme.domains=${BTCPAY_HOST},www.${BTCPAY_HOST}"
+      - "traefik.acme.email=${LETSENCRYPT_EMAIL}"

--- a/docker-compose-generator/docker-fragments/traefik-labels.yml
+++ b/docker-compose-generator/docker-fragments/traefik-labels.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  btcpayserver:
+    labels:
+      - "traefik.backend=btcpayserver"
+      - "traefik.backend.loadbalancer.sticky=true"
+      - "traefik.enable=true"
+      - "traefik.frontend.rule=Host:${BTCPAY_HOST}"
+      - "traefik.port.rule=49392"

--- a/docker-compose-generator/docker-fragments/traefik.yml
+++ b/docker-compose-generator/docker-fragments/traefik.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+  traefik:
+    restart: unless-stopped
+    image: traefik
+    container_name: traefik
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock"
+    - "./traefik.toml:/traefik.toml"
+    - "./acme.json:/acme.json"
+    - "./servers.toml:/servers.toml"
+    - "./traefik_logs:/traefik_logs"
+    links:
+      - btcpayserver
+
+volumes:
+  traefik_logs:

--- a/docker-compose-generator/docker-fragments/traefik.yml
+++ b/docker-compose-generator/docker-fragments/traefik.yml
@@ -9,11 +9,12 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock"
-    - "./traefik.toml:/traefik.toml"
-    - "./acme.json:/acme.json"
-    - "./servers.toml:/servers.toml"
-    - "./traefik_logs:/traefik_logs"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./traefik.toml:/traefik.toml"
+      - "./acme.json:/acme.json"
+      - "./servers.toml:/servers.toml"
+      - "./traefik_logs:/traefik_logs"
+      
     links:
       - btcpayserver
 

--- a/docker-compose-generator/src/DockerComposition.cs
+++ b/docker-compose-generator/src/DockerComposition.cs
@@ -42,6 +42,15 @@ namespace DockerGenerator
 			composition.SelectedProxy = (Environment.GetEnvironmentVariable("BTCPAYGEN_REVERSEPROXY") ?? "").ToLowerInvariant();
 			composition.SelectedLN = (Environment.GetEnvironmentVariable("BTCPAYGEN_LIGHTNING") ?? "").ToLowerInvariant();
 			composition.AdditionalFragments = (Environment.GetEnvironmentVariable("BTCPAYGEN_ADDITIONAL_FRAGMENTS") ?? "").ToLowerInvariant().Split(';').Where(t => !string.IsNullOrWhiteSpace(t)).ToArray();
+			if (composition.SelectedProxy == "traefik" && !composition.AdditionalFragments.Contains("traefik-labels"))
+			{
+				var additionalFragments = new List<string>();
+				additionalFragments.AddRange(composition.AdditionalFragments);
+				additionalFragments.Add("traefik-labels");
+
+				composition.AdditionalFragments = additionalFragments.ToArray();
+			}
+
 			return composition;
 		}
 	}

--- a/docker-compose-generator/src/Program.cs
+++ b/docker-compose-generator/src/Program.cs
@@ -19,7 +19,7 @@ namespace DockerGenerator
 				var productionLocation = Path.GetFullPath(Path.Combine(root, "Production"));
 				var testLocation = Path.GetFullPath(Path.Combine(root, "Production-NoReverseProxy"));
 
-				foreach(var proxy in new[] { "nginx", "no-reverseproxy", "traefik", "emit-traefik-labels" })
+				foreach(var proxy in new[] { "nginx", "no-reverseproxy", "traefik" })
 				{
 					foreach(var lightning in new[] { "clightning", "" })
 					{
@@ -40,6 +40,10 @@ namespace DockerGenerator
 								composition.SelectedCryptos.Add(ltc);
 								composition.SelectedLN = lightning;
 								composition.SelectedProxy = proxy;
+								if (composition.SelectedProxy == "traefik")
+								{
+									composition.AdditionalFragments = new []{"traefik-labels"};
+								}
 								new Program().Run(composition, name, new string[] {"nginx", "traefik"}.Contains(proxy)? productionLocation : testLocation);
 							}
 						}
@@ -74,12 +78,9 @@ namespace DockerGenerator
 					fragments.Add("nginx");
 					break;
 				case "traefik":
-
 					fragments.Add("traefik");
 					break;
-				case "emit-traefik-labels":
 				case "no-reverseproxy":
-
 					fragments.Add("btcpayserver-noreverseproxy");
 					break;
 			}

--- a/docker-compose-generator/src/Program.cs
+++ b/docker-compose-generator/src/Program.cs
@@ -19,7 +19,7 @@ namespace DockerGenerator
 				var productionLocation = Path.GetFullPath(Path.Combine(root, "Production"));
 				var testLocation = Path.GetFullPath(Path.Combine(root, "Production-NoReverseProxy"));
 
-				foreach(var proxy in new[] { "nginx", "no-reverseproxy" })
+				foreach(var proxy in new[] { "nginx", "no-reverseproxy", "traefik", "emit-traefik-labels" })
 				{
 					foreach(var lightning in new[] { "clightning", "" })
 					{
@@ -40,7 +40,7 @@ namespace DockerGenerator
 								composition.SelectedCryptos.Add(ltc);
 								composition.SelectedLN = lightning;
 								composition.SelectedProxy = proxy;
-								new Program().Run(composition, name, proxy == "nginx" ? productionLocation : testLocation);
+								new Program().Run(composition, name, new string[] {"nginx", "traefik"}.Contains(proxy)? productionLocation : testLocation);
 							}
 						}
 					}
@@ -67,13 +67,21 @@ namespace DockerGenerator
 			fragmentLocation = Path.GetFullPath(Path.Combine(fragmentLocation, "docker-fragments"));
 
 			var fragments = new List<string>();
-			if(composition.SelectedProxy == "nginx")
+			switch (@composition.SelectedProxy)
 			{
-				fragments.Add("nginx");
-			}
-			else
-			{
-				fragments.Add("btcpayserver-noreverseproxy");
+				case "nginx":
+
+					fragments.Add("nginx");
+					break;
+				case "traefik":
+
+					fragments.Add("traefik");
+					break;
+				case "emit-traefik-labels":
+				case "no-reverseproxy":
+
+					fragments.Add("btcpayserver-noreverseproxy");
+					break;
 			}
 			fragments.Add("btcpayserver");
 			foreach(var crypto in CryptoDefinition.GetDefinitions())

--- a/docker-compose-generator/src/docker-compose-generator.csproj
+++ b/docker-compose-generator/src/docker-compose-generator.csproj
@@ -10,4 +10,33 @@
 	  <PackageReference Include="YamlDotNet" Version="4.3.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\docker-fragments\.gitignore" />
+    <Content Include="..\docker-fragments\bgold-lnd.yml" />
+    <Content Include="..\docker-fragments\bgold.yml" />
+    <Content Include="..\docker-fragments\bitcoin-clightning.yml" />
+    <Content Include="..\docker-fragments\bitcoin-lnd.yml" />
+    <Content Include="..\docker-fragments\bitcoin.yml" />
+    <Content Include="..\docker-fragments\btcpayserver-noreverseproxy.yml" />
+    <Content Include="..\docker-fragments\btcpayserver.yml" />
+    <Content Include="..\docker-fragments\feathercoin.yml" />
+    <Content Include="..\docker-fragments\groestlcoin.yml" />
+    <Content Include="..\docker-fragments\litecoin-clightning.yml" />
+    <Content Include="..\docker-fragments\litecoin-lnd.yml" />
+    <Content Include="..\docker-fragments\litecoin.yml" />
+    <Content Include="..\docker-fragments\nginx.yml" />
+    <Content Include="..\docker-fragments\opt-lnd-autopilot.yml" />
+    <Content Include="..\docker-fragments\opt-save-storage-s.yml" />
+    <Content Include="..\docker-fragments\opt-save-storage-xs.yml" />
+    <Content Include="..\docker-fragments\opt-save-storage-xxs.yml" />
+    <Content Include="..\docker-fragments\opt-save-storage.yml" />
+    <Content Include="..\docker-fragments\traefik-labels.yml">
+      <Link>opt-save-storage.yml</Link>
+    </Content>
+    <Content Include="..\docker-fragments\traefik.yml">
+      <Link>nginx.yml</Link>
+    </Content>
+    <Content Include="..\docker-fragments\viacoin.yml" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR adds support to run BTCPayServer behind traefik.
You either set the reverse proxy env var to "traefik" or else specify an additional fragment "traefik-labels" which tags the btcpayserver server and allows it to be discovered by an already running traefik container.

Just need to test. :)