### PR TITLE
wip:attempt adding rpc explorer support

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin-rpc-explorer.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-rpc-explorer.yml
@@ -7,12 +7,8 @@ services:
     environment:
       RPC_HOST: bitcoind
       RPC_PORT: 43782
+      RPC_COOKIEFILE: /nodes/bitcoin/.cookie
     links:
       - bitcoind
     volumes:
-    - "bitcoin_datadir:/deps/.bitcoin" 
-  bitcoind:
-    environment:
-      # If you don't use Lightning Network, you want this
-      # This save about 2 weeks worth of block
-      BITCOIN_EXTRA_ARGS: prune=5000
+    - "bitcoin_datadir:/nodes/bitcoin" 

--- a/docker-compose-generator/docker-fragments/bitcoin-rpc-explorer.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-rpc-explorer.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  bitcoin-rpc-explorer:
+    restart: unless-stopped
+    image: oktapodia/btc-rpc-explorer
+    environment:
+      RPC_HOST: bitcoind
+      RPC_PORT: 43782
+    links:
+      - bitcoind
+    volumes:
+    - "bitcoin_datadir:/deps/.bitcoin" 
+  bitcoind:
+    environment:
+      # If you don't use Lightning Network, you want this
+      # This save about 2 weeks worth of block
+      BITCOIN_EXTRA_ARGS: prune=5000

--- a/docker-compose-generator/src/CryptoDefinition.cs
+++ b/docker-compose-generator/src/CryptoDefinition.cs
@@ -26,6 +26,12 @@ namespace DockerGenerator
             get;
             private set;
         }
+	    public string RPCExplorerFragment
+	    {
+		    get;
+		    private set;
+	    }
+
 
         public static CryptoDefinition[] GetDefinitions()
         {
@@ -43,7 +49,8 @@ namespace DockerGenerator
                     Crypto = "btc",
                     CryptoFragment = "bitcoin",
                     CLightningFragment = "bitcoin-clightning",
-                    LNDFragment = "bitcoin-lnd"
+                    LNDFragment = "bitcoin-lnd",
+                    RPCExplorerFragment = "bitcoin-rpc-explorer"
                 },
                 new CryptoDefinition()
                 {


### PR DESCRIPTION
Integrates https://github.com/janoside/btc-rpc-explorer into btcpayserver as an optional service. There is a limitation with how the generator is structured though and not sure how to handle exposing this dynamic fragment through the reverse proxy. We also need https://github.com/janoside/btc-rpc-explorer/issues/59 to make this work properly.

