### PR TITLE
Longer timeout for grpc stream endpoints

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -251,6 +251,9 @@ server {
 	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;
 	ssl_session_tickets off;
+	proxy_connect_timeout 1d;
+	proxy_send_timeout 1d;
+	proxy_read_timeout 1d;	
 
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
 	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};


### PR DESCRIPTION
subscribeInvoice() grpc stream endpoint is cut off after 1 min or so. I guessed it is because of the nginx default timeout.
This change sets 1 day for long connection. I have tested with node.js grpc client and at least the connection is not forced to get cut off with this change.
I am not so sure whether 1 day is too long or too short. or even whether BTCPay does not need to expose it. 