### PR TITLE
Add BTX support

### DIFF
--- a/bitcore-cli.ps1
+++ b/bitcore-cli.ps1
@@ -1,0 +1,1 @@
+docker exec -ti btcpayserver_bitcored bitcore-cli -datadir="/data" $args

--- a/bitcore-cli.sh
+++ b/bitcore-cli.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -ti btcpayserver_bitcored bitcore-cli -datadir="/data" "$@"

--- a/btcpay-setup.sh
+++ b/btcpay-setup.sh
@@ -52,7 +52,7 @@ Environment variables:
     LETSENCRYPT_EMAIL: A mail will be sent to this address if certificate expires and fail to renew automatically (eg. me@example.com)
     NBITCOIN_NETWORK: The type of network to use (eg. mainnet, testnet or regtest. Default: mainnet)
     LIGHTNING_ALIAS: An alias for your lightning network node if used
-    BTCPAYGEN_CRYPTO1: First supported crypto currency (eg. btc, ltc, btg, grs, ftc, via, doge, mona, none. Default: btc)
+    BTCPAYGEN_CRYPTO1: First supported crypto currency (eg. btc, ltc, btx, btg, grs, ftc, via, doge, mona, none. Default: btc)
     BTCPAYGEN_CRYPTO2: Second supported crypto currency (Default: empty)
     BTCPAYGEN_CRYPTON: N th supported crypto currency where N is maximum at maximum 9. (Default: none)
     BTCPAYGEN_REVERSEPROXY: Whether to use or not a reverse proxy. NGinx setup HTTPS for you. (eg. nginx, traefik, none. Default: nginx)

--- a/docker-compose-generator/docker-fragments/bitcore.yml
+++ b/docker-compose-generator/docker-fragments/bitcore.yml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+  bitcored:
+    restart: unless-stopped
+    container_name: btcpayserver_bitcored
+    image: dalijolijo/docker-bitcore:0.15.2
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        rpcport=43782
+        ${NBITCOIN_NETWORK:-regtest}=1
+        port=39388
+        whitelist=0.0.0.0/0
+    expose:
+      - "43782"
+      - "39388"
+    volumes:
+      - "bitcore_datadir:/data"
+  nbxplorer:
+      environment:
+        NBXPLORER_CHAINS: "btx"
+        NBXPLORER_BTXRPCURL: http://bitcored:43782/
+        NBXPLORER_BTXNODEENDPOINT: bitcored:39388
+      links:
+        - bitcored
+      volumes:
+        - "bitcore_datadir:/root/.bitcore"
+  btcpayserver:
+      environment:
+        BTCPAY_BTXEXPLORERURL: http://nbxplorer:32838/
+        BTCPAY_CHAINS: "btx"
+
+volumes:
+    bitcore_datadir:

--- a/docker-compose-generator/docker-fragments/nbxplorer.yml
+++ b/docker-compose-generator/docker-fragments/nbxplorer.yml
@@ -4,7 +4,7 @@ services:
 
   nbxplorer:
     restart: unless-stopped
-    image: nicolasdorier/nbxplorer:2.0.0.1
+    image: nicolasdorier/nbxplorer:2.0.0.2
     expose: 
       - "32838"
     environment:

--- a/docker-compose-generator/docker-fragments/opt-save-storage-s.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-storage-s.yml
@@ -6,6 +6,9 @@ services:
   bitcoind:
     environment:
       BITCOIN_EXTRA_ARGS: prune=50000
+  bitcored:
+    environment:
+      BITCOIN_EXTRA_ARGS: prune=50000
   bgoldd:
     environment:
       BITCOIN_EXTRA_ARGS: prune=50000

--- a/docker-compose-generator/docker-fragments/opt-save-storage-xs.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-storage-xs.yml
@@ -6,6 +6,9 @@ services:
   bitcoind:
     environment:
       BITCOIN_EXTRA_ARGS: prune=25000
+  bitcored:
+    environment:
+      BITCOIN_EXTRA_ARGS: prune=25000
   bgoldd:
     environment:
       BITCOIN_EXTRA_ARGS: prune=25000

--- a/docker-compose-generator/docker-fragments/opt-save-storage-xxs.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-storage-xxs.yml
@@ -6,6 +6,9 @@ services:
   bitcoind:
     environment:
       BITCOIN_EXTRA_ARGS: prune=5000
+  bitcored:
+    environment:
+      BITCOIN_EXTRA_ARGS: prune=5000
   bgoldd:
     environment:
       BITCOIN_EXTRA_ARGS: prune=5000

--- a/docker-compose-generator/docker-fragments/opt-save-storage.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-storage.yml
@@ -6,6 +6,9 @@ services:
   bitcoind:
     environment:
       BITCOIN_EXTRA_ARGS: prune=100000
+  bitcored:
+    environment:
+      BITCOIN_EXTRA_ARGS: prune=100000
   bgoldd:
     environment:
       BITCOIN_EXTRA_ARGS: prune=100000

--- a/docker-compose-generator/src/CryptoDefinition.cs
+++ b/docker-compose-generator/src/CryptoDefinition.cs
@@ -47,6 +47,11 @@ namespace DockerGenerator
                 },
                 new CryptoDefinition()
                 {
+                    Crypto = "btx",
+                    CryptoFragment = "bitcore",
+                },
+                new CryptoDefinition()
+                {
                     Crypto = "btg",
                     CryptoFragment = "bgold",
                     LNDFragment = "bgold-lnd"


### PR DESCRIPTION
- The docker image **docker-bitcore** v0.15.2 for Bitcore BTX you can find on [hub.docker.com](https://hub.docker.com/r/dalijolijo/docker-bitcore/tags/)

- The sources (Dockerfile and docker-entrypoint.sh) are available on [GitHub]( https://github.com/dalijolijo/btcpayserver-docker-bitcore)