### PR TITLE
btcpay version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ You can read [the article](https://medium.com/@BtcpayServer/hosting-btcpay-serve
 * `BTCPAY_HOST_SSHKEYFILE`: Optional, SSH private key that BTCPay can use to connect to this VM's SSH server. This key will be copied to BTCPay's data directory
 * `BTCPAY_SSHTRUSTEDFINGERPRINTS`: Optional, BTCPay will ensure that it is connecting to the expected SSH server by checking the host's public key against these fingerprints
 * `BTCPAYGEN_DOCKER_IMAGE`: Optional, Specify which generator image to use if you have customized the C# generator. Set to `btcpayserver/docker-compose-generator:local` to build the generator locally at runtime.
+* `BTCPAY_VERSION`: Optional, Specify which btcpayserver image to use if you have a customized btcpayserver.
 
 # Tooling
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can read [the article](https://medium.com/@BtcpayServer/hosting-btcpay-serve
 * `BTCPAY_HOST_SSHKEYFILE`: Optional, SSH private key that BTCPay can use to connect to this VM's SSH server. This key will be copied to BTCPay's data directory
 * `BTCPAY_SSHTRUSTEDFINGERPRINTS`: Optional, BTCPay will ensure that it is connecting to the expected SSH server by checking the host's public key against these fingerprints
 * `BTCPAYGEN_DOCKER_IMAGE`: Optional, Specify which generator image to use if you have customized the C# generator. Set to `btcpayserver/docker-compose-generator:local` to build the generator locally at runtime.
-* `BTCPAY_VERSION`: Optional, Specify which btcpayserver image to use if you have a customized btcpayserver.
+* `BTCPAY_IMAGE`: Optional, Specify which btcpayserver image to use if you have a customized btcpayserver.
 
 # Tooling
 

--- a/btcpay-setup.sh
+++ b/btcpay-setup.sh
@@ -61,7 +61,7 @@ Environment variables:
     ACME_CA_URI: The API endpoint to ask for HTTPS certificate (default: https://acme-v01.api.letsencrypt.org/directory)
     BTCPAY_HOST_SSHKEYFILE: Optional, SSH private key that BTCPay can use to connect to this VM's SSH server. This key will be copied on BTCPay's data directory
     BTCPAYGEN_DOCKER_IMAGE: Allows you to specify a custom docker image for the generator (Default: btcpayserver/docker-compose-generator)
-    BTCPAY_VERSION: Allows you to specify the btcpayserver docker image to use over the default version. (Default: current stable version of btcpayserver)
+    BTCPAY_IMAGE: Allows you to specify the btcpayserver docker image to use over the default version. (Default: current stable version of btcpayserver)
 END
 }
 
@@ -135,7 +135,7 @@ BTCPAYGEN_CRYPTO9:$BTCPAYGEN_CRYPTO9
 BTCPAYGEN_REVERSEPROXY:$BTCPAYGEN_REVERSEPROXY
 BTCPAYGEN_LIGHTNING:$BTCPAYGEN_LIGHTNING
 BTCPAYGEN_ADDITIONAL_FRAGMENTS:$BTCPAYGEN_ADDITIONAL_FRAGMENTS
-BTCPAY_VERSION:$BTCPAY_VERSION
+BTCPAY_IMAGE:$BTCPAY_IMAGE
 ACME_CA_URI:$ACME_CA_URI
 ----------------------
 Additional exported variables:
@@ -185,7 +185,7 @@ export BTCPAY_ENV_FILE=\"$BTCPAY_ENV_FILE\"
 export BTCPAY_HOST_SSHKEYFILE=\"$BTCPAY_HOST_SSHKEYFILE\"
 if cat \$BTCPAY_ENV_FILE &> /dev/null; then
 export BTCPAY_HOST=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^BTCPAY_HOST=\(.*\)$/\1/p')\"
-export BTCPAY_VERSION=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^BTCPAY_VERSION=\(.*\)$/\1/p')\"
+export BTCPAY_IMAGE=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^BTCPAY_IMAGE=\(.*\)$/\1/p')\"
 export LETSENCRYPT_EMAIL=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^LETSENCRYPT_EMAIL=\(.*\)$/\1/p')\"
 export NBITCOIN_NETWORK=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^NBITCOIN_NETWORK=\(.*\)$/\1/p')\"
 export LIGHTNING_ALIAS=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^LIGHTNING_ALIAS=\(.*\)$/\1/p')\"
@@ -202,7 +202,7 @@ echo -e "BTCPay Server environment variables successfully saved in /etc/profile.
 touch $BTCPAY_ENV_FILE
 echo "
 BTCPAY_HOST=$BTCPAY_HOST
-BTCPAY_VERSION=$BTCPAY_VERSION
+BTCPAY_IMAGE=$BTCPAY_IMAGE
 ACME_CA_URI=$ACME_CA_URI
 NBITCOIN_NETWORK=$NBITCOIN_NETWORK
 LETSENCRYPT_EMAIL=$LETSENCRYPT_EMAIL

--- a/btcpay-setup.sh
+++ b/btcpay-setup.sh
@@ -61,6 +61,7 @@ Environment variables:
     ACME_CA_URI: The API endpoint to ask for HTTPS certificate (default: https://acme-v01.api.letsencrypt.org/directory)
     BTCPAY_HOST_SSHKEYFILE: Optional, SSH private key that BTCPay can use to connect to this VM's SSH server. This key will be copied on BTCPay's data directory
     BTCPAYGEN_DOCKER_IMAGE: Allows you to specify a custom docker image for the generator (Default: btcpayserver/docker-compose-generator)
+    BTCPAY_VERSION: Allows you to specify the btcpayserver docker image to use over the default version. (Default: current stable version of btcpayserver)
 END
 }
 
@@ -134,6 +135,7 @@ BTCPAYGEN_CRYPTO9:$BTCPAYGEN_CRYPTO9
 BTCPAYGEN_REVERSEPROXY:$BTCPAYGEN_REVERSEPROXY
 BTCPAYGEN_LIGHTNING:$BTCPAYGEN_LIGHTNING
 BTCPAYGEN_ADDITIONAL_FRAGMENTS:$BTCPAYGEN_ADDITIONAL_FRAGMENTS
+BTCPAY_VERSION:$BTCPAY_VERSION
 ACME_CA_URI:$ACME_CA_URI
 ----------------------
 Additional exported variables:
@@ -183,6 +185,7 @@ export BTCPAY_ENV_FILE=\"$BTCPAY_ENV_FILE\"
 export BTCPAY_HOST_SSHKEYFILE=\"$BTCPAY_HOST_SSHKEYFILE\"
 if cat \$BTCPAY_ENV_FILE &> /dev/null; then
 export BTCPAY_HOST=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^BTCPAY_HOST=\(.*\)$/\1/p')\"
+export BTCPAY_VERSION=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^BTCPAY_VERSION=\(.*\)$/\1/p')\"
 export LETSENCRYPT_EMAIL=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^LETSENCRYPT_EMAIL=\(.*\)$/\1/p')\"
 export NBITCOIN_NETWORK=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^NBITCOIN_NETWORK=\(.*\)$/\1/p')\"
 export LIGHTNING_ALIAS=\"\$(cat \$BTCPAY_ENV_FILE | sed -n 's/^LIGHTNING_ALIAS=\(.*\)$/\1/p')\"
@@ -199,6 +202,7 @@ echo -e "BTCPay Server environment variables successfully saved in /etc/profile.
 touch $BTCPAY_ENV_FILE
 echo "
 BTCPAY_HOST=$BTCPAY_HOST
+BTCPAY_VERSION=$BTCPAY_VERSION
 ACME_CA_URI=$ACME_CA_URI
 NBITCOIN_NETWORK=$NBITCOIN_NETWORK
 LETSENCRYPT_EMAIL=$LETSENCRYPT_EMAIL

--- a/docker-compose-generator/docker-fragments/btcpayserver.yml
+++ b/docker-compose-generator/docker-fragments/btcpayserver.yml
@@ -4,7 +4,7 @@ services:
 
   btcpayserver:
     restart: unless-stopped
-    image: ${BTCPAY_VERSION:-nicolasdorier/btcpayserver:nicolasdorier/btcpayserver:1.0.3.9}
+    image: ${BTCPAY_IMAGE:-nicolasdorier/btcpayserver:nicolasdorier/btcpayserver:1.0.3.9}
     expose:
       - "49392"
     environment:

--- a/docker-compose-generator/docker-fragments/btcpayserver.yml
+++ b/docker-compose-generator/docker-fragments/btcpayserver.yml
@@ -4,7 +4,7 @@ services:
 
   btcpayserver:
     restart: unless-stopped
-    image: nicolasdorier/btcpayserver:1.0.3.9
+    image: ${BTCPAY_VERSION:-nicolasdorier/btcpayserver:nicolasdorier/btcpayserver:1.0.3.9}
     expose:
       - "49392"
     environment:


### PR DESCRIPTION
Allow a user to specify their own docker image for btcpayserver via `BTCPAY_VERSION`