### PR TITLE
LibrePatron Version Update

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
@@ -3,7 +3,7 @@ services:
     librepatron:
         container_name: librepatron
         restart: unless-stopped
-        image: jvandrew/librepatron:0.6.69
+        image: jvandrew/librepatron:0.6.71
         expose:
             - "8006"
         volumes:
@@ -22,7 +22,6 @@ services:
     isso:
         container_name: isso
         restart: unless-stopped
-        stop_signal: SIGKILL
         image: jvandrew/isso:atron.22
         expose:
             - "8080"


### PR DESCRIPTION
**Primary reason for this PR:** This PR updates LibrePatron to v0.6.71. This version upgrade contains backend improvements to ensure that subscriber renewals go out even if the server is offline at the exact renewal date/time.

**Secondary reason for this PR:** This PR also removes the `stop_signal: SIGKILL` from the isso container in the relevant Docker fragment. That signal was only necessary for isso container versions prior to `atron:22`. In `atron:22`, `tini` was implemented in that container, making SIGKILL unnecessary for proper container stoppage. The isso container shuts down properly with the standard Docker `SIGTERM` so the line is unncessary.