### PR TITLE
Quickbooks Update for New "taxIncluded" Field

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.1.20
+    image: jvandrew/btcqbo:0.2.4
     environment:
       REDIS_URL: "redis://redis:6379/0"
       BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
@@ -12,7 +12,7 @@ services:
     links: 
       - redis
   rq-worker:
-    image: jvandrew/btcqbo:0.1.20
+    image: jvandrew/btcqbo:0.2.4
     entrypoint: /usr/local/bin/rq
     command: worker -u redis://redis:6379/0 btcqbo
     environment:

--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.2.11
+    image: jvandrew/btcqbo:0.2.12
     environment:
       REDIS_URL: "redis://redis:6379/0"
       BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
@@ -12,7 +12,7 @@ services:
     links: 
       - redis
   rq-worker:
-    image: jvandrew/btcqbo:0.2.11
+    image: jvandrew/btcqbo:0.2.12
     entrypoint: /usr/local/bin/rq
     command: worker -u redis://redis:6379/0 btcqbo
     environment:

--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.2.8
+    image: jvandrew/btcqbo:0.2.11
     environment:
       REDIS_URL: "redis://redis:6379/0"
       BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
@@ -12,7 +12,7 @@ services:
     links: 
       - redis
   rq-worker:
-    image: jvandrew/btcqbo:0.2.8
+    image: jvandrew/btcqbo:0.2.11
     entrypoint: /usr/local/bin/rq
     command: worker -u redis://redis:6379/0 btcqbo
     environment:

--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.2.4
+    image: jvandrew/btcqbo:0.2.8
     environment:
       REDIS_URL: "redis://redis:6379/0"
       BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
@@ -12,7 +12,7 @@ services:
     links: 
       - redis
   rq-worker:
-    image: jvandrew/btcqbo:0.2.4
+    image: jvandrew/btcqbo:0.2.8
     entrypoint: /usr/local/bin/rq
     command: worker -u redis://redis:6379/0 btcqbo
     environment:


### PR DESCRIPTION
Now that BTCPay supports `taxIncluded` on invoices, BTCQBO is no longer limited to users who send invoices directly from Quickbooks.

Most online merchants do not invoice directly from Quickbooks, so before `taxIncluded` was integrated, the plugin had no use to them.

BTCQBO now has two "modes":

1. Invoice Mode: This was previously the only mode. This is for users who send invoices directly from Quickbooks.

2. Deposit Mode. This was enabled by `taxIncluded`. Now merchants that do not send invoices directly from Quickbooks can simply have Quickbooks record all BTCPay paid invoices directly into Quickbooks, with revenue and sales tax appropriately apportioned.

In Deposit Mode, merchants must set the Quickbooks Plugin as `notificationUrl`, however, they can set an IPN Forwarding URL in the plugin itself. After the plugin receives the IPN, it will forward it to its ultimate destination.

So a hypothetical online merchant would have the relevant IPN sent to BTCQBO where Quickbooks would record the payment, and BTCQBO would then forward the IPN to the relevant merchant solution so that the merchant knows that the relevant items could be shipped.