### PR TITLE
Fix LibrePatron Lightning Bug

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
@@ -3,7 +3,7 @@ services:
     librepatron:
         container_name: librepatron
         restart: unless-stopped
-        image: jvandrew/librepatron:0.6.75
+        image: jvandrew/librepatron:0.6.76
         expose:
             - "8006"
         volumes:

--- a/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
@@ -3,7 +3,7 @@ services:
     librepatron:
         container_name: librepatron
         restart: unless-stopped
-        image: jvandrew/librepatron:0.6.71
+        image: jvandrew/librepatron:0.6.75
         expose:
             - "8006"
         volumes:


### PR DESCRIPTION
LibrePatron had a bug where it did not properly handle IPNs on certain lightning payments, due to the payment status hitting "complete" so quickly. This update fixes that bug.