### PR TITLE
Fix Lightning Bug in BTC-QBO

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.2.12
+    image: jvandrew/btcqbo:0.3.13
     environment:
       REDIS_URL: "redis://redis:6379/0"
       BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
@@ -12,7 +12,8 @@ services:
     links: 
       - redis
   rq-worker:
-    image: jvandrew/btcqbo:0.2.12
+    image: jvandrew/btcqbo:0.3.13
+    stop_signal: SIGKILL
     entrypoint: /usr/local/bin/rq
     command: worker -u redis://redis:6379/0 btcqbo
     environment:


### PR DESCRIPTION
The same bug that caused lightning payments to not always register correctly in LibrePatron also affected BTCQBO. This PR bumps the version to a version that implements the fix.

It also adds `stop_signal: SIGKILL` to the container running the RQ worker. Because the worker runs an infinite loop of refreshing Intuit Oauth tokens, running `. btcpay-setup.sh -i` would sometimes hang on the RQ-Worker container. Implementing the `SIGKILL` prevents the hang issue.