### PR TITLE
Version Update for BTC-QBO

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.3.24
+    image: jvandrew/btcqbo:0.3.25
     environment:
       REFRESH_MINS: 50
       REDIS_HOST: "redis"

--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.3.13
+    image: jvandrew/btcqbo:0.3.18
     environment:
       REDIS_URL: "redis://redis:6379/0"
       BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
@@ -12,7 +12,7 @@ services:
     links: 
       - redis
   rq-worker:
-    image: jvandrew/btcqbo:0.3.13
+    image: jvandrew/btcqbo:0.3.18
     stop_signal: SIGKILL
     entrypoint: /usr/local/bin/rq
     command: worker -u redis://redis:6379/0 btcqbo

--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,22 +2,13 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.3.18
+    image: jvandrew/btcqbo:0.3.24
     environment:
+      REFRESH_MINS: 50
+      REDIS_HOST: "redis"
       REDIS_URL: "redis://redis:6379/0"
       BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
       CALLBACK_URL: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/btcqbo/qbologged
-    expose:
-      - "8001"
-    links: 
-      - redis
-  rq-worker:
-    image: jvandrew/btcqbo:0.3.18
-    stop_signal: SIGKILL
-    entrypoint: /usr/local/bin/rq
-    command: worker -u redis://redis:6379/0 btcqbo
-    environment:
-      REDIS_URL: "redis://redis:6379/0"
     expose:
       - "8001"
     links: 


### PR DESCRIPTION
Version 0.3.24 of BTC-QBO contains backend efficiency improvements:

1. The RQ-Worker container is no longer necessary, as Quickbooks Oauth refresh is now accomplished via scheduled interval jobs stored directly to Redis.

2. Processing of IPNs is handled more efficiently.

These changes are designed to minimize the amount of system resources required by BTC-QBO. It should be as "light" as possible when doing its job.