### PR TITLE
Update LibrePatron (two items)

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
@@ -3,13 +3,14 @@ services:
     librepatron:
         container_name: librepatron
         restart: unless-stopped
-        image: jvandrew/librepatron:0.6.76
+        image: jvandrew/librepatron:0.6.78
         expose:
             - "8006"
         volumes:
             - data-volume:/var/lib/db
             - config-volume:/var/lib/config
         environment:
+            BTCPAY_HOST: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}
             COMMENTS_SUBURI: "1"
             SITEURL: ${BTCPAY_PROTOCOL:-https}://${LIBREPATRON_HOST}
             SECRET_KEY_LOCATION: /var/lib/db/key


### PR DESCRIPTION
1. This PR passes `BTCPAY_HOST` to LibrePatron's container. In future versions, this will allow me to automatically generate the BTCPay pairing URL for LibrePatron users. (This was a feature originally suggested by @NicolasDorier.)

2. This updates LibrePatron to v0.6.78. This new version updates the subscription scheduler backend with database persistence.