### PR TITLE
Add Web Dashboard for lnd (via Ride the Lightning)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,20 @@ jobs:
             sudo docker build --pull -t $DOCKERHUB_REPO:latest-amd64 -f linuxamd64.Dockerfile .
             sudo docker push $DOCKERHUB_REPO:latest-amd64
 
+  publish_docker_linuxarm32v7:
+    machine:
+      docker_layer_caching: true
+    steps:
+      - checkout  
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            #
+            cd docker-compose-generator
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker build --pull -t $DOCKERHUB_REPO:latest-arm32v7 -f linuxarm32v7.Dockerfile .
+            sudo docker push $DOCKERHUB_REPO:latest-arm32v7
+
   publish_docker_multiarch:
     machine:
       enabled: true
@@ -39,21 +53,15 @@ workflows:
       - publish_docker_linuxamd64:
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: dcg-latest
       - publish_docker_linuxarm32v7:
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: dcg-latest
       - publish_docker_multiarch:
           requires:
             - publish_docker_linuxamd64
             - publish_docker_linuxarm32v7
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: dcg-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,20 +14,6 @@ jobs:
             sudo docker build --pull -t $DOCKERHUB_REPO:latest-amd64 -f linuxamd64.Dockerfile .
             sudo docker push $DOCKERHUB_REPO:latest-amd64
 
-  publish_docker_linuxarm32v7:
-    machine:
-      docker_layer_caching: true
-    steps:
-      - checkout  
-      - run:
-          command: |
-            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
-            #
-            cd docker-compose-generator
-            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
-            sudo docker build --pull -t $DOCKERHUB_REPO:latest-arm32v7 -f linuxarm32v7.Dockerfile .
-            sudo docker push $DOCKERHUB_REPO:latest-arm32v7
-
   publish_docker_multiarch:
     machine:
       enabled: true
@@ -53,15 +39,21 @@ workflows:
       - publish_docker_linuxamd64:
           filters:
             branches:
-              only: dcg-latest
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       - publish_docker_linuxarm32v7:
           filters:
             branches:
-              only: dcg-latest
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
       - publish_docker_multiarch:
           requires:
             - publish_docker_linuxamd64
             - publish_docker_linuxarm32v7
           filters:
             branches:
-              only: dcg-latest
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/

--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -320,6 +320,15 @@ server {
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	}
 		{{ end }}
+		{{ if (eq $serviceName "lnd_bitcoin_rtl") }}
+	location /rtl/ {
+		proxy_pass http://lnd_bitcoin_rtl:3000;
+		proxy_redirect off;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	}
+		{{ end }}
 		{{ if (eq $serviceName "clightning_bitcoin_spark") }}
 	location /spark/btc/ {
 		proxy_pass http://clightning_bitcoin_spark:9737/;

--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -311,7 +311,7 @@ server {
 	}
 		{{ end }}
 		{{ if (eq $serviceName "lnd_bitcoin_rtl") }}
-	location /rtl/btc/ {
+	location /rtl/ {
 		proxy_pass http://lnd_bitcoin_rtl:3000/rtl/;
 	}
 		{{ end }}

--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -1,5 +1,4 @@
-{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
-
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }} 
 {{ define "upstream" }}
 	{{ if .Address }}
 		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
@@ -311,18 +310,17 @@ server {
 		proxy_pass http://lnd_bitcoin:8080/;
 	}
 		{{ end }}
+		{{ if (eq $serviceName "lnd_bitcoin_rtl") }}
+	location /rtl/ {
+		proxy_pass http://lnd_bitcoin_rtl:3000/;
+	}
+	location /api/ {
+		proxy_pass http://lnd_bitcoin_rtl:3000/api/;
+	}
+		{{ end }}
 		{{ if (eq $serviceName "btcqbo") }}
 	location /btcqbo/ {
 		proxy_pass http://btcqbo:8001;
-		proxy_redirect off;
-		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "lnd_bitcoin_rtl") }}
-	location /rtl/ {
-		proxy_pass http://lnd_bitcoin_rtl:3000;
 		proxy_redirect off;
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;

--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -312,10 +312,7 @@ server {
 		{{ end }}
 		{{ if (eq $serviceName "lnd_bitcoin_rtl") }}
 	location /rtl/ {
-		proxy_pass http://lnd_bitcoin_rtl:3000/;
-	}
-	location /api/ {
-		proxy_pass http://lnd_bitcoin_rtl:3000/api/;
+		proxy_pass http://lnd_bitcoin_rtl:3000/rtl/;
 	}
 		{{ end }}
 		{{ if (eq $serviceName "btcqbo") }}

--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -311,7 +311,7 @@ server {
 	}
 		{{ end }}
 		{{ if (eq $serviceName "lnd_bitcoin_rtl") }}
-	location /rtl/ {
+	location /rtl/btc/ {
 		proxy_pass http://lnd_bitcoin_rtl:3000/rtl/;
 	}
 		{{ end }}

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -38,16 +38,17 @@ services:
       - bitcoind
 
   lnd_bitcoin_rtl:
-    image: shahanafarooqui/rtl:0.2.5
+    image: shahanafarooqui/rtl:0.2.6
     restart: unless-stopped
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1
       MACAROON_PATH: /etc/lnd
       LND_CONFIG_PATH: /etc/lnd/lnd.conf
       RTL_CONFIG_PATH: /data/RTL.conf
-      BITCOIND_CONFIG_PATH: /etc/bitcoin/bitcoin.conf
+      BITCOIND_CONFIG_PATH: etc/bitcoin/bitcoin.conf
       RTL_SSO: 1
       RTL_COOKIE_PATH: /data/.cookie
+      REVERSE_PROXY: 1
       LOGOUT_REDIRECT_LINK: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/server/services
     volumes:
       - "bitcoin_datadir:/etc/bitcoin"

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -38,7 +38,7 @@ services:
       - bitcoind
 
   lnd_bitcoin_rtl:
-    image: shahanafarooqui/rtl:0.2.6
+    image: shahanafarooqui/rtl:0.2.7
     restart: unless-stopped
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -45,7 +45,7 @@ services:
       MACAROON_PATH: /etc/lnd
       LND_CONFIG_PATH: /etc/lnd/lnd.conf
       RTL_CONFIG_PATH: /data/RTL.conf
-      BITCOIND_CONFIG_PATH: etc/bitcoin/bitcoin.conf
+      BITCOIND_CONFIG_PATH: /etc/bitcoin/bitcoin.conf
       RTL_SSO: 1
       RTL_COOKIE_PATH: /data/.cookie
       LOGOUT_REDIRECT_LINK: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/server/services

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -45,7 +45,7 @@ services:
       MACAROON_PATH: /etc/lnd
       LND_CONFIG_PATH: /etc/lnd/lnd.conf
       RTL_CONFIG_PATH: /data/RTL.conf
-      BITCOIND_CONFIG_PATH: etc/bitcoin/bitcoin.conf
+      BITCOIND_CONFIG_PATH: /etc/bitcoin/bitcoin.conf
       RTL_SSO: 1
       RTL_COOKIE_PATH: /data/.cookie
       REVERSE_PROXY: 1

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -45,17 +45,14 @@ services:
       MACAROON_PATH: /etc/lnd
       LND_CONFIG_PATH: /etc/lnd/lnd.conf
       RTL_CONFIG_PATH: /data/RTL.conf
-      BITCOIND_CONFIG_PATH: /etc/bitcoin/bitcoin.conf
+      BITCOIND_CONFIG_PATH: etc/bitcoin/bitcoin.conf
       RTL_SSO: 1
       RTL_COOKIE_PATH: /data/.cookie
       LOGOUT_REDIRECT_LINK: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/server/services
-      VIRTUAL_SERVICE_NAME: "rtl"
     volumes:
       - "bitcoin_datadir:/etc/bitcoin"
       - "lnd_bitcoin_datadir:/etc/lnd"
       - "lnd_bitcoin_rtl_datadir:/data"
-    links:
-      - lnd_bitcoin
     expose:
       - "3000"
 
@@ -69,7 +66,6 @@ services:
       - "lnd_bitcoin_rtl_datadir:/etc/lnd_bitcoin_rtl"
     links:
       - lnd_bitcoin
-      - lnd_bitcoin_rtl
 
   bitcoind:
     environment:

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -38,7 +38,7 @@ services:
       - bitcoind
 
   lnd_bitcoin_rtl:
-    image: shahanafarooqui/rtl:0.2.4
+    image: shahanafarooqui/rtl:0.2.5
     restart: unless-stopped
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -59,7 +59,7 @@ services:
   btcpayserver:
     environment:
       BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=http://lnd_bitcoin:8080/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;allowinsecure=true"
-      BTCPAY_BTCEXTERNALSPARK: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/btc/;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
+      BTCPAY_BTCEXTERNALRTL: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/btc/;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
       BTCPAY_BTCEXTERNALLNDGRPC: "type=lnd-grpc;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
       BTCPAY_BTCEXTERNALLNDREST: "type=lnd-rest;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/lnd-rest/btc/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
     volumes:

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -66,6 +66,7 @@ services:
       BTCPAY_BTCEXTERNALLNDREST: "type=lnd-rest;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/lnd-rest/btc/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
     volumes:
       - "lnd_bitcoin_datadir:/etc/lnd_bitcoin"
+      - "lnd_bitcoin_rtl_datadir:/etc/lnd_bitcoin_rtl"
     links:
       - lnd_bitcoin
       - lnd_bitcoin_rtl

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -59,6 +59,7 @@ services:
   btcpayserver:
     environment:
       BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=http://lnd_bitcoin:8080/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;allowinsecure=true"
+      BTCPAY_BTCEXTERNALSPARK: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/btc/;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
       BTCPAY_BTCEXTERNALLNDGRPC: "type=lnd-grpc;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
       BTCPAY_BTCEXTERNALLNDREST: "type=lnd-rest;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/lnd-rest/btc/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
     volumes:

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -48,7 +48,6 @@ services:
       BITCOIND_CONFIG_PATH: /etc/bitcoin/bitcoin.conf
       RTL_SSO: 1
       RTL_COOKIE_PATH: /data/.cookie
-      REVERSE_PROXY: 1
       LOGOUT_REDIRECT_LINK: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/server/services
     volumes:
       - "bitcoin_datadir:/etc/bitcoin"

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -37,6 +37,28 @@ services:
       - nbxplorer
       - bitcoind
 
+  lnd_bitcoin_rtl:
+    image: shahanafarooqui/rtl:0.2.1
+    restart: unless-stopped
+    environment:
+      LND_SERVER_URL: http://lnd_bitcoin:8080/v1
+      MACAROON_PATH: /etc/lnd
+      LND_CONFIG_PATH: /etc/lnd/lnd.conf
+      RTL_CONFIG_PATH: /data/RTL.conf
+      BITCOIND_CONFIG_PATH: /etc/bitcoin/bitcoin.conf
+      RTL_SSO: 1
+      RTL_COOKIE_PATH: /data/.cookie
+      LOGOUT_REDIRECT_LINK: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/server/users
+      VIRTUAL_SERVICE_NAME: "rtl"
+    volumes:
+      - "bitcoin_datadir:/etc/bitcoin"
+      - "lnd_bitcoin_datadir:/etc/lnd"
+      - "lnd_bitcoin_rtl_datadir:/data"
+    links:
+      - lnd_bitcoin
+    expose:
+      - "3000"
+
   btcpayserver:
     environment:
       BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=http://lnd_bitcoin:8080/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;allowinsecure=true"
@@ -46,6 +68,7 @@ services:
       - "lnd_bitcoin_datadir:/etc/lnd_bitcoin"
     links:
       - lnd_bitcoin
+      - lnd_bitcoin_rtl
 
   bitcoind:
     environment:
@@ -69,3 +92,4 @@ services:
 
 volumes:
   lnd_bitcoin_datadir:
+  lnd_bitcoin_rtl_datadir:

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -59,7 +59,7 @@ services:
   btcpayserver:
     environment:
       BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=http://lnd_bitcoin:8080/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;allowinsecure=true"
-      BTCPAY_BTCEXTERNALRTL: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/btc/;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
+      BTCPAY_BTCEXTERNALRTL: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
       BTCPAY_BTCEXTERNALLNDGRPC: "type=lnd-grpc;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
       BTCPAY_BTCEXTERNALLNDREST: "type=lnd-rest;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/lnd-rest/btc/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
     volumes:

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -38,7 +38,7 @@ services:
       - bitcoind
 
   lnd_bitcoin_rtl:
-    image: shahanafarooqui/rtl:0.2.7
+    image: shahanafarooqui/rtl:0.2.10
     restart: unless-stopped
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -38,14 +38,14 @@ services:
       - bitcoind
 
   lnd_bitcoin_rtl:
-    image: shahanafarooqui/rtl:0.2.1
+    image: shahanafarooqui/rtl:0.2.3
     restart: unless-stopped
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1
       MACAROON_PATH: /etc/lnd
       LND_CONFIG_PATH: /etc/lnd/lnd.conf
       RTL_CONFIG_PATH: /data/RTL.conf
-      BITCOIND_CONFIG_PATH: /etc/bitcoin/bitcoin.conf
+      BITCOIND_CONFIG_PATH: etc/bitcoin/bitcoin.conf
       RTL_SSO: 1
       RTL_COOKIE_PATH: /data/.cookie
       LOGOUT_REDIRECT_LINK: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/server/services

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -59,7 +59,7 @@ services:
   btcpayserver:
     environment:
       BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=http://lnd_bitcoin:8080/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;allowinsecure=true"
-      BTCPAY_BTCEXTERNALRTL: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
+      BTCPAY_BTCEXTERNALRTL: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/authenticate/cookie;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
       BTCPAY_BTCEXTERNALLNDGRPC: "type=lnd-grpc;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
       BTCPAY_BTCEXTERNALLNDREST: "type=lnd-rest;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/lnd-rest/btc/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
     volumes:

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -59,7 +59,7 @@ services:
   btcpayserver:
     environment:
       BTCPAY_BTCLIGHTNING: "type=lnd-rest;server=http://lnd_bitcoin:8080/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;allowinsecure=true"
-      BTCPAY_BTCEXTERNALRTL: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/authenticate/cookie;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
+      BTCPAY_BTCEXTERNALRTL: "server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}${BTCPAY_ROOTPATH:-/}rtl/api/authenticate/cookie;cookiefile=/etc/lnd_bitcoin_rtl/.cookie"
       BTCPAY_BTCEXTERNALLNDGRPC: "type=lnd-grpc;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
       BTCPAY_BTCEXTERNALLNDREST: "type=lnd-rest;server=${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/lnd-rest/btc/;macaroonfilepath=/etc/lnd_bitcoin/admin.macaroon;macaroondirectorypath=/etc/lnd_bitcoin"
     volumes:

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -38,7 +38,7 @@ services:
       - bitcoind
 
   lnd_bitcoin_rtl:
-    image: shahanafarooqui/rtl:0.2.3
+    image: shahanafarooqui/rtl:0.2.4
     restart: unless-stopped
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1


### PR DESCRIPTION
Currently when a BTCPay user selects c-lightning as his lightning implementation, he is able to access a nice web-based dashboard to control his lightning node through BTCPay's integration with Spark. Unfortunately until now there has been no similar option for lnd.

To rectify this issue. I reached out to @saubyk and @ShahanaFarooqui, who are the developers of the Ride the Lightning project (RTL), and I offered to help Dockerize RTL in a way that would integrate with BTCPay. 

@saubyk and @ShahanaFarooqui did all the real work in developing RTL; I just provided a hand with Docker and making things BTCPay-friendly.

The idea behind this PR is that it will add RTL to BTCPay for lnd in exactly the same way Spark is integrated into BTCPay for c-lightning. To that end, for authentication RTL generates a "cookie file" just like Spark generates a cookie file (as was suggested by @NicolasDorier here: https://github.com/shesek/spark-wallet/pull/8). Just like with the Spark BTCPay integration, the cookie file is a text file that stores a randomly generated access key.

This PR changes the docker fragment for lnd to add a container for RTL, to exactly mirror the way that the c-lightning fragment adds a container for Spark. I have tested this myself on a BTCPay instance and have had no issues.

In addition to merging this PR, the following steps would need to be taken in the BTCPay code itself to make this work:

- [ ] Alter the nginx template to host RTL on a sub-URI, presumably `https://<btcpay-host>/rtl`
- [ ] Expose a new link for RTL in the BTCPay admin panel under Server Settings -->Services, as has been done for Spark. Just like with Spark, the linked URL should be followed by `?access-key=<access-key>`. In the Docker fragment I prepared for this PR, the RTL data volume is linked to the BTCPay Server container at `/etc/lnd_bitcoin_rtl` so the cookie file containing the access key should be at `/etc/lnd_bitcoin_rtl/.cookie`.

For any questions about RTL itself, I'm sure @saubyk and @ShahanaFarooqui can answer. I can provide any answers about the docker fragment or BTCPay integration.