### PR TITLE
BTCQBO: Add Email Receipts to Deposit Mode (by user request)

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.3.27
+    image: jvandrew/btcqbo:0.3.28
     environment:
       REFRESH_MINS: 50
       REDIS_HOST: "redis"

--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.3.25
+    image: jvandrew/btcqbo:0.3.27
     environment:
       REFRESH_MINS: 50
       REDIS_HOST: "redis"

--- a/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-btcqbo.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   btcqbo:
-    image: jvandrew/btcqbo:0.3.28
+    image: jvandrew/btcqbo:0.3.32
     environment:
       REFRESH_MINS: 50
       REDIS_HOST: "redis"


### PR DESCRIPTION
New version of BTCQBO with backend efficiency improvements.

EDIT: At the request of a Mattermost user, this PR has been updated to allow email receipts for merchants using "Deposit Mode."

This feature request was made by "klebe" in Mattermost/Slack.