### PR TITLE
Update LibrePatron (Security Fix)

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
@@ -3,7 +3,7 @@ services:
     librepatron:
         container_name: librepatron
         restart: unless-stopped
-        image: jvandrew/librepatron:0.7.33
+        image: jvandrew/librepatron:0.7.34
         expose:
             - "8006"
         volumes:

--- a/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
@@ -3,7 +3,7 @@ services:
     librepatron:
         container_name: librepatron
         restart: unless-stopped
-        image: jvandrew/librepatron:0.7.31
+        image: jvandrew/librepatron:0.7.32
         expose:
             - "8006"
         volumes:

--- a/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-librepatron.yml
@@ -3,7 +3,7 @@ services:
     librepatron:
         container_name: librepatron
         restart: unless-stopped
-        image: jvandrew/librepatron:0.7.32
+        image: jvandrew/librepatron:0.7.33
         expose:
             - "8006"
         volumes:


### PR DESCRIPTION
One of the LibrePatron dependencies (jinja2) reported a security vulnerability; this updates the jinja2 version to one that patches the vulnerability.