### PR TITLE
Add a simple template mechanism for fragments

### DIFF
--- a/docker-compose-generator/src/DockerComposeDefinition.cs
+++ b/docker-compose-generator/src/DockerComposeDefinition.cs
@@ -35,7 +35,7 @@ namespace DockerGenerator
 		{
 			return Path.Combine(BuildOutputDirectory, $"docker-compose.{_Name}.yml");
 		}
-		public void Build()
+		public void Build(Dictionary<string, string> data = null)
 		{
 			Console.WriteLine($"Generating {GetFilePath()}");
 			var deserializer = new DeserializerBuilder().Build();
@@ -82,9 +82,19 @@ namespace DockerGenerator
 			output.Add("services", new YamlMappingNode(Merge(services)));
 			output.Add("volumes", new YamlMappingNode(volumes));
 			output.Add("networks", new YamlMappingNode(networks));
-			var result = serializer.Serialize(output);
+			var result = serializer.Serialize(output)
+				.Replace("''", "");
+			if (data != null && data.Any())
+			{
+				foreach (var keyValuePair in data)
+				{
+					result = result.Replace($"#{keyValuePair.Key}#", keyValuePair.Value);
+				}
+			}
 			var outputFile = GetFilePath();
-			File.WriteAllText(outputFile, result.Replace("''", ""));
+			File.WriteAllText(outputFile, result);
+			
+			
 			Console.WriteLine($"Generated {outputFile}");
 			Console.WriteLine();
 		}

--- a/docker-compose-generator/src/Program.cs
+++ b/docker-compose-generator/src/Program.cs
@@ -35,7 +35,6 @@ namespace DockerGenerator
 			switch (composition.SelectedProxy)
 			{
 				case "nginx":
-
 					fragments.Add("nginx");
 					fragments.Add("btcpayserver-nginx");
 					break;
@@ -76,7 +75,10 @@ namespace DockerGenerator
 			var def = new DockerComposeDefinition(name, fragments.ToList());
 			def.FragmentLocation = fragmentLocation;
 			def.BuildOutputDirectory = output;
-			def.Build();
+			def.Build(new Dictionary<string, string>()
+			{
+				{ "CRYPTOS", string.Join(';', composition.SelectedCryptos)}
+			} );
 		}
 
 		private static string FindRoot(string rootDirectory)


### PR DESCRIPTION
This small change extends the generator to be able to replace placeholder test in fragments. Right now I'm only using it for an internal value (Cryptos, replaces #CRYPTOS# in the generated yml with the selected crypto codes e.g.: "BTC;LTC") but it could prove to be useful for other things later on.