### PR TITLE
Moved symlinks to binaries to /usr/local/bin as /usr/bin is protected…

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -36,8 +36,8 @@ install_tooling() {
         if [ -e "$scriptname" ]; then
             if [ "$dependency" == "*" ] || grep -q "$dependency" "$BTCPAY_DOCKER_COMPOSE"; then
                 chmod +x $scriptname
-                ln -s "$(pwd)/$scriptname" /usr/bin
-                echo "Installed $scriptname to /usr/bin: $comment"
+                ln -s "$(pwd)/$scriptname" /usr/local/bin
+                echo "Installed $scriptname to /usr/local/bin: $comment"
             fi
         else
             echo "WARNING: Script $scriptname referenced, but not existing"


### PR DESCRIPTION
Moved symlink location to `/usr/local/bin` because `/usr/bin` is write protected on Mac OS and meant for OS supplied binaries only. This theory applies to other OS as well and should be considered better practise.

Since `/usr/local/bin` has precedence over `/usr/bin` in the standard PATH, there is no danger to break existing installations.

One could argue that previously created symlinks should be removed, but I see no danger in keeping them. The new symlinks will be used anyway.