### PR TITLE
fix: proxy all lnrpc grpc interfaces

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -26,7 +26,7 @@
 	{{ range $container := $.Containers }}
 		{{ $serviceName := (index $container.Labels "com.docker.compose.service") }}
 		{{ if (eq $serviceName "lnd_bitcoin") }}
-	location /lnrpc.Lightning {
+	location /lnrpc {
 		grpc_pass grpcs://lnd_bitcoin:10009;
 	}
 	location /lnd-rest/btc/ {


### PR DESCRIPTION
## Description

This PR updates the lnd grpc proxy to ensure that the `WalletUnlocker` interface is accessible in addition to the `Lightning` interface.

## Motivation

https://github.com/LN-Zap/zap-desktop/issues/2535
## Context

The Lnd gRPC service is broken up into subservers. Initially there were just 2 interfaces (`WalletUnlocker` and `Lightning`) however as lnd has developed more and more of the gRPC service is being broken down into various smaller and more focussed subservers.

Many of the lnd gRPC libraries such as https://github.com/LN-Zap/node-lnd-grpc attempt to determine the state of lnd (locked or unlocked) by probing the api and looking out for specific grpc status codes.

For example, `node-lnd-grpc` attempts to call a method against the `WalletUnlocker` service and uses the grpc status code in order to determine wether the node is locked or not.

Currently, BTCPayServer does not forward requests to the `WalletUnlocker` service and nginx just returns with a http 404 error code. gRPC libraries such as [grpc-node](https://github.com/grpc/grpc-node) can not interpret an nginx http 404 error code properly as it does not follow the grpc standard in which the gRPC service is expected to return with a grpc-status code 12 (`UNIMPLEMENTED`).

With the current setup the lnd node running on BTCPay Server behaves differently to a standard lnd node that is not running behind an nginx proxy and as a result standard grpc libraries do not function as expected.

This PR makes the lnd instance behave more like any other lnd instance.