### PR TITLE
Add opt-moar-memory to increase dbcache to 1GB in bitcoin.conf

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-moar-memory.yml
+++ b/docker-compose-generator/docker-fragments/opt-moar-memory.yml
@@ -1,0 +1,32 @@
+version: "3"
+# If your machine has moar than 1GB of memory dedicated for bitcoind, use this
+
+services:
+  bitcoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024
+  bgoldd:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024
+  feathercoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024
+  groestlcoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024
+  litecoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024
+  viacoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024
+  monacoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024


### PR DESCRIPTION
My new Raspberry Pi 4 with 4GB of ram laughs at your opt-save-memory setting