### PR TITLE
Add custom docker fragment to expose bitcoind P2P on TCP/8333

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Available `BTCPAYGEN_ADDITIONAL_FRAGMENTS` currently are:
 * [opt-add-tor](docker-compose-generator/docker-fragments/opt-add-tor.yml), for exposing BTCPayServer, Woocommerce, your lightning nodes as hidden services and accept onion peers for your full node. Warning: This options is for working around NAT and firewall problems as well as to help protect your customer's privacy. This will not protect your privacy against a targeted attack against you.
 * [opt-add-btctransmuter](docker-compose-generator/docker-fragments/opt-add-btctransmuter.yml), for a self-hosted IFTTT style service for crypto services such as fiat settlement.
 * [opt-txindex](docker-compose-generator/docker-fragments/opt-txindex.yml), to enable txindex=1 in bitcoin.conf if you require txindexing for Bisq, DOJO, Esplora, etc.
+* [opt-unsafe-expose](docker-compose-generator/docker-fragments/opt-unsafe-expose.yml), to unsafely expose bitcoind P2P port 8333 if you require P2P for Bisq, DOJO, Esplora, etc. WARNING: ONLY USE ON TRUSTED LAN OR WITH FIREWALL RULES WHITELISTING SPECIFIC HOSTS
 
 You can also create your own [custom fragments](#how-can-i-customize-the-generated-docker-compose-file).
 

--- a/docker-compose-generator/docker-fragments/opt-expose-unsafe.yml
+++ b/docker-compose-generator/docker-fragments/opt-expose-unsafe.yml
@@ -1,0 +1,7 @@
+version: "3"
+# unsafely exposes bitcoind P2P port, for use on trusted LAN only
+
+services:
+  bitcoind:
+      ports:
+        - "8333:39388"


### PR DESCRIPTION
According to the official BTCPay documentation, it says to open port TCP/8333 on the firewall. But for some reason, it seems the docker configuration does not expose TCP/8333 from the Bitcoin container to the outside world. https://docs.btcpayserver.org/deployment/manualdeployment/manualdeploymentextended

Am I missing something, or shouldn't this be exposed? I want to use the Bitcoin node inside BTCPay for things other than BTCPay on my LAN, for example Bisq needs to connect to a full node. If this is a security configuration, I would expect there to be an option to expose it, but I couldn't find one. Is this a bug?