### PR TITLE
Add litecoin datadir to exclude

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -31,7 +31,7 @@ elif [ ${BACKUP_PROVIDER="Dropbox"} ]; then
         docker volume create backup_datadir
     fi	
     btcpay-down.sh
-    tar --exclude='/var/lib/docker/volumes/backup_datadir/*' --exclude='/var/lib/docker/volumes/generated_bitcoin_datadir/*' -cvzf /var/lib/docker/volumes/backup_datadir/_data/${filename} /var/lib/docker/volumes
+    tar --exclude='/var/lib/docker/volumes/backup_datadir/*' --exclude='/var/lib/docker/volumes/generated_bitcoin_datadir/*' --exclude='/var/lib/docker/volumes/generated_litecoin_datadir/*' -cvzf /var/lib/docker/volumes/backup_datadir/_data/${filename} /var/lib/docker/volumes
     btcpay-up.sh
     echo "Uploading to Dropbox..."
     docker run --name backup --env DROPBOX_TOKEN=$DROPBOX_TOKEN -v backup_datadir:/data jvandrew/btcpay-dropbox:1.0.5 $filename


### PR DESCRIPTION
If you are running a litecoin node, litecoin datadir does not need to be included. It is only exclude, so no error in case of pure bitcoin install.