### PR TITLE
Extend backup.sh to allow backup using btcpay's storage provider

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -47,4 +47,21 @@ elif [ ${BACKUP_PROVIDER="Dropbox"} ]; then
     docker run --name backup --env DROPBOX_TOKEN=$DROPBOX_TOKEN -v backup_datadir:/data jvandrew/btcpay-dropbox:1.0.5 $filename
     echo "Deleting local backup..."
     rm /var/lib/docker/volumes/backup_datadir/_data/${filename}
+elif [ ${BACKUP_PROVIDER="BTCPayDropFolder"} ]; then
+    if [ -z ${1+x} ]; then
+	filename="backup.tar.gz"
+    else
+	filename=$1
+    fi	
+    if [ ! -d /var/lib/docker/volumes/backup_datadir ]; then
+        docker volume create backup_datadir
+    fi	
+    btcpay-down.sh
+    tar --exclude='/var/lib/docker/volumes/backup_datadir/*' \
+    --exclude='/var/lib/docker/volumes/generated_bitcoin_datadir/*' \
+    --exclude='/var/lib/docker/volumes/generated_litecoin_datadir/*' \
+    --exclude='/var/lib/docker/volumes/generated_btcpay_dropdir/*' \
+    -cvzf /var/lib/docker/volumes/generated_btcpay_dropdir/${filename} /var/lib/docker/volumes
+    btcpay-up.sh
+    echo "Backup created and sent to BTCPay's drop folder, queued for upload"
 fi

--- a/docker-compose-generator/docker-fragments/btcpayserver.yml
+++ b/docker-compose-generator/docker-fragments/btcpayserver.yml
@@ -18,12 +18,15 @@ services:
       BTCPAY_SSHKEYFILE: ${BTCPAY_SSHKEYFILE}
       BTCPAY_SSHAUTHORIZEDKEYS: ${BTCPAY_SSHAUTHORIZEDKEYS}
       BTCPAY_DEBUGLOG: btcpay.log
+      BTCPAy_STORAGEDROPFOLDER: dropfolder
     links:
       - postgres
     volumes:
      - "btcpay_datadir:/datadir"
+     - "btcpay_dropdir:/dropfolder"
      - "nbxplorer_datadir:/root/.nbxplorer"
      - "$<BTCPAY_HOST_SSHAUTHORIZEDKEYS>?:${BTCPAY_SSHAUTHORIZEDKEYS}"
 
 volumes:
     btcpay_datadir:
+    btcpay_dropdir:


### PR DESCRIPTION
This uses the upcoming new feature in btcpay for an automatic storage drop folder https://github.com/btcpayserver/btcpayserver/pull/1054/files  to upload a backup of the btcpay data to any of the supported cloud storage providers.