### PR TITLE
lnd-channels-remote-backup-on-change

### DIFF
--- a/lnd-channels-backup-dependencies.sh
+++ b/lnd-channels-backup-dependencies.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# run as root
+if [ "$(id -u)" != "0" ]; then
+    echo "This script must be run as root."
+    echo "Use the command 'sudo su -' and try again"
+    exit 1
+fi
+
+# generate LND backup ssh key
+if [ -f /root/.ssh/lnd_backup ]; then
+    echo "Key exists"
+else
+    echo "Generating SSH key"
+    ssh-keygen -o -a 100 -t ed25519 -f /root/.ssh/lnd_backup -N ''
+fi
+
+# check and install rsync and inotify
+echo "Checking rsync and inotify..."
+for pkgs in rsync inotify-tools; do
+        if [ $(dpkg -s $pkgs 2>/dev/null | grep -c "ok installed") -eq 1 ]; then
+                echo "$pkgs is already installed "
+        else
+                apt -yy install $pkgs
+                echo "Successfully installed $pkgs "
+        fi
+done
+
+# check and install rclone
+echo "Checking rclone..."
+if command -v rclone 2>/dev/null -eq 1; then
+        echo "rclone is already installed"
+else
+        curl https://rclone.org/install.sh | bash
+        echo "Successfully installed rclone"
+fi

--- a/lnd-channels-backup-systemd.sh
+++ b/lnd-channels-backup-systemd.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+sudo su -
+
+    echo "Adding backup-channels.service to systemd"
+    echo "
+[Service]
+ExecStart=/root/btcpayserver/lnd-channels-remote-backup-on-change.sh
+Restart=always
+RestartSec=1
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=backup-channels
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target" > /etc/systemd/system/backup-channels.service
+
+systemctl daemon-reload
+systemctl start backup-channels
+systemctl enable backup-channels
+    echo "OK"

--- a/lnd-channels-remote-backup-on-change.sh
+++ b/lnd-channels-remote-backup-on-change.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#  This script is inspired by Alex Bosworth's idea to automate static channels backup (SCB) on local disk
+#  https://gist.github.com/alexbosworth/2c5e185aedbdac45a03655b709e255a3
+#  However one more step is required to instantly backup the latest SCB on a remote server (off-site) in case of LND server crash.
+#  This script will copy SCB to remote server(s) and/or cloud storage(s) of your choice.
+  
+
+lnd_channel_backup="/var/lib/docker/volumes/generated_lnd_bitcoin_datadir/_data/data/chain/bitcoin/mainnet/channel.backup"
+key="/root/.ssh/lnd_backup"
+
+# You need provide your remote server credentials and rclone remote name below after copying btcserver ssh key to remote servers 
+# and/or configuring rclone accordingly.
+# You can add as many remote servers and clouds as you want by adding extra variables and modifying the script
+
+remote_server1="YOUR_REMOTE_SERVER_USER_NAME@YOUR_REMOTE_SERVER_IP:~/btcpayserver/"
+cloud1="YOUR_RCLONE_REMOTE:btcpayserver/"
+
+while true; do
+    /usr/bin/inotifywait -r -e modify,attrib,close_write,move,create,delete ${lnd_channel_backup}
+    /usr/bin/rsync -az -e "ssh -i ${key}" ${lnd_channel_backup} ${remote_server1}
+    /usr/bin/rclone sync ${lnd_channel_backup} ${cloud1} --config /root/.config/rclone/rclone.conf
+done


### PR DESCRIPTION
Currently BTCPay Server docker on every change in channels state saves static channels backup (SCB) locally on the same disk (on-site). This poses a threat to LN off-chain funds recovery in case of the server crash or fatal data loss.
Every time a change is made to channel.backup file in BTCPay Server docker it will instantly be copied to set up remotes.
This will allow you to keep the latest SCB offsite (on a remote server and/or popular cloud).
NOTE: this has been tested on Linux systems only.
TO BE CONTINUED ...)