### PR TITLE
Add Electrumx low memory config

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-save-memory.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-memory.yml
@@ -7,6 +7,10 @@ services:
       BITCOIN_EXTRA_ARGS: |
         dbcache=50
         maxmempool=50
+  electrumx:
+    environment:
+      - CACHE_MB=50
+      - MAX_SESSIONS=100
   bgoldd:
     environment:
       BITCOIN_EXTRA_ARGS: |


### PR DESCRIPTION
This is untested but just saw the `opt-save-memory.yml` and thought I'd add some settings for Electrumx. It can be quite resource intensive, especially when it has a lot of connections.

Will these get correctly merged in to the `electrumx` block in the resulting `docker-compose.yml`?