### PR TITLE
Add fallback fee

### DIFF
--- a/docker-compose-generator/docker-fragments/liquid.yml
+++ b/docker-compose-generator/docker-fragments/liquid.yml
@@ -17,6 +17,7 @@ services:
           whitelist=0.0.0.0/0
           validatepegin=0
           prune=5000
+          fallbackfee=0.000001
       expose:
         - "43782"
         - "39388"


### PR DESCRIPTION
A fully synced node often fails to estimate fees:

Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.

Adding fee of 0.1sat/vB