### PR TITLE
missing btcpay-restart.sh command in tooling section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ A wide variety of useful scripts are available once BTCPay is installed:
 * `btcpay-setup.sh`: Change the settings of your server
 * `. ./btcpay-setup.sh`: Information about additional parameters
 * `. ./btcpay-setup.sh -i`: Set up your BTCPayServer
+* `btcpay-restart.sh`: Restart your BTCPayServer
 
 # Under the hood
 


### PR DESCRIPTION
line 139 added `btcpay-restart.sh`: Restart your BTCPayServer