### PR TITLE
change line to . ./btcpay-setup.sh -I line  177

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ You can also create your own [custom fragments](#how-can-i-customize-the-generat
 If you want to add an option to `BTCPAYGEN_ADDITIONAL_FRAGMENTS` and re-configure your install:
 ```bash
 export BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-lnd-autopilot"
-. btcpay-setup.sh -i
+. ./btcpay-setup.sh -i
 ```
 
 For example, if you want `btc` and `ltc` support with `nginx` and `clightning` inside `Generated/docker-compose.custom.yml`:


### PR DESCRIPTION
both Method works
.
. .
but this is the way describe in btcpay tooling scripts .

extra info for newbies
On Unix-like operating systems every directory contains, as a minimum, an object represented by a single dot and another represented by two successive dots. The former refers to the directory itself and the latter refers to its parent directory (i.e., the directory that contains it).