### PR TITLE
Add tip on changedomain.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ A wide variety of useful scripts are available once BTCPay is installed:
 
 * `bitcoin-cli.sh`: Access your Bitcoin node instance (for RPC)
 * `bitcoin-lightning-cli.sh`: Access your C-Lightning node instance (for RPC)
-* `changedomain.sh`: Change the domain of your BTCPayServer
+* `changedomain.sh`: Change the domain of your BTCPayServer (remember to disable 2FA/U2F first, as you risk being unable to log in to your account)
 * `btcpay-update.sh`: Update BTCPayServer to the latest version
 * `btcpay-up.sh`: Run `docker-compose up`
 * `btcpay-down.sh`: Run `docker-compose down`


### PR DESCRIPTION
If you change the domain while U2F is active, you can no longer connect to the account.
This PR adds a little tip in the README.md file but I think it should also be shown inside BTCPay.

Can we create something like
`if` U2F is enabled
`then` display alert message/confirmation for changedomain.sh
?