### PR TITLE
Deleting LND volume on old installations

### DIFF
--- a/Tools/recreate_bitcoin_lnd.sh
+++ b/Tools/recreate_bitcoin_lnd.sh
@@ -21,6 +21,10 @@ fi
 
 docker volume rm --force generated_lnd_bitcoin_datadir
 
+# very old installations had production_lnd_bitcoin_datadir volume
+# https://github.com/btcpayserver/btcpayserver-docker/issues/272
+docker volume rm --force production_lnd_bitcoin_datadir
+
 ../btcpay-up.sh
 
 echo "LND container recreated"


### PR DESCRIPTION
If volume is not present it won't throw any kind of error, it'll just echo volume name

![image](https://user-images.githubusercontent.com/5191402/88696672-27071180-d0c9-11ea-8151-7d1a66effea4.png)

Resolves: #272 