### PR TITLE
fix: thunderhub url

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-thunderhub.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-thunderhub.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
     btcpayserver:
         environment:
-            BTCPAY_BTCEXTERNALTHUNDERHUB: "server=/thub/sso/;cookiefile=/etc/lnd_bitcoin_thub_datadir/.cookie"
+            BTCPAY_BTCEXTERNALTHUNDERHUB: "server=/thub/sso;cookiefile=/etc/lnd_bitcoin_thub_datadir/.cookie"
         volumes:
             - "lnd_bitcoin_thub_datadir:/etc/lnd_bitcoin_thub_datadir"
     bitcoin_thub:


### PR DESCRIPTION
It was redirecting to `/sso` instead of `/thub/sso` because of this extra `/`