### PR TITLE
bump dogecoin

### DIFF
--- a/docker-compose-generator/docker-fragments/dogecoin.yml
+++ b/docker-compose-generator/docker-fragments/dogecoin.yml
@@ -4,7 +4,7 @@ services:
   dogecoind:
     restart: unless-stopped
     container_name: btcpayserver_dogecoind
-    image: rockstardev/dogecoin:1.10.0
+    image: btcpayserver/dogecoin:1.14.2
     environment:
       DOGECOIN_EXTRA_ARGS: |
         rpcuser=ceiwHEbqWI83


### PR DESCRIPTION
This.. In theory.. will move dogecoin to the docker-deps repo instead of @rockstardev's fork.

