### PR TITLE
Migrate to DNSBL and bump version to v0.17.1.8

### DIFF
--- a/docker-compose-generator/docker-fragments/monero.yml
+++ b/docker-compose-generator/docker-fragments/monero.yml
@@ -4,8 +4,8 @@ services:
   monerod:
     restart: unless-stopped
     container_name: btcpayserver_monerod
-    image: btcpayserver/monero:0.17.1.7
-    entrypoint: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --ban-list=/home/monero/block.txt
+    image: btcpayserver/monero:0.17.1.8
+    entrypoint: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
     expose:
       - "18081"
     volumes:
@@ -13,7 +13,7 @@ services:
   monerod_wallet:
     restart: unless-stopped
     container_name: btcpayserver_monero_wallet
-    image: btcpayserver/monero:0.17.1.7
+    image: btcpayserver/monero:0.17.1.8
     entrypoint: monero-wallet-rpc --rpc-bind-ip=0.0.0.0 --disable-rpc-login --confirm-external-bind --rpc-bind-port=18082 --non-interactive --trusted-daemon  --daemon-address=monerod:18081 --wallet-file=/wallet/wallet --password-file=/wallet/password --tx-notify="/bin/sh ./scripts/notifier.sh  -X GET http://btcpayserver:49392/monerolikedaemoncallback/tx?cryptoCode=xmr&hash=%s"
     expose:
       - "18082"


### PR DESCRIPTION
Utilize new flag `--enable-dns-blocklist` to ban known-malicious hosts instead of the file-based --ban-list.

This reduces complexity both here and in Monero/*/linuxamd64.Dockerfile.