### PR TITLE
DOGE RPC Security Fix + addnode fragment + memory fixes for DOGE

### DIFF
--- a/btcpay-setup.sh
+++ b/btcpay-setup.sh
@@ -333,7 +333,14 @@ if [[ "$NBITCOIN_NETWORK" != "mainnet" ]] && [[ "$NBITCOIN_NETWORK" != "testnet"
     echo "NBITCOIN_NETWORK should be equal to mainnet, testnet or regtest"
 fi
 
-
+if [[ $BTCPAY_CRYPTOS == *"doge"* ]]; then
+        echo "Found DOGE, generating unique RPC username and password for security"
+        random_user=$(date +%s | sha256sum | base64 | head -c 32 ; echo) ; sleep 1 ; random_pass=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+        perl -pi -e 's/rpcuser=.*/'"rpcuser=$random_user"'/g' docker-compose-generator/docker-fragments/dogecoin.yml
+        perl -pi -e 's/rpcpassword=.*/'"rpcpassword=$random_pass"'/g' docker-compose-generator/docker-fragments/dogecoin.yml
+        perl -pi -e 's/NBXPLORER_DOGERPCUSER: .*/'"NBXPLORER_DOGERPCUSER: $random_user"'/g' docker-compose-generator/docker-fragments/dogecoin.yml
+        perl -pi -e 's/NBXPLORER_DOGERPCPASSWORD: .*/'"NBXPLORER_DOGERPCPASSWORD: $random_pass"'/g' docker-compose-generator/docker-fragments/dogecoin.yml
+fi
 
 # Init the variables when a user log interactively
 touch "$BASH_PROFILE_SCRIPT"

--- a/docker-compose-generator/docker-fragments/dogecoin.yml
+++ b/docker-compose-generator/docker-fragments/dogecoin.yml
@@ -14,9 +14,6 @@ services:
         rpcport=22555
         port=22556
         whitelist=0.0.0.0/0
-        # Reducing memory usage of dogecoind. Don't try running this container without at least 2 GB of memory
-        # https://www.reddit.com/r/dogecoin/comments/5wynqe/reducing_memory_usage_of_dogecoind/
-        dbcache=50
     ports:
       - "22555:22555"
     expose:

--- a/docker-compose-generator/docker-fragments/opt-addnodes.yml
+++ b/docker-compose-generator/docker-fragments/opt-addnodes.yml
@@ -4,7 +4,7 @@ version: "3"
 services:
   dogecoind:
     environment:
-      BITCOIN_EXTRA_ARGS: |
+      DOGECOIN_EXTRA_ARGS: |
         addnode=coins.prohashing.com:6003
   feathercoind:
     environment:

--- a/docker-compose-generator/docker-fragments/opt-addnodes.yml
+++ b/docker-compose-generator/docker-fragments/opt-addnodes.yml
@@ -1,0 +1,26 @@
+version: "3"
+# Uses addnodes from Prohashing explorers for faster syncing! 
+
+services:
+  dogecoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        addnode=coins.prohashing.com:6003
+  feathercoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        addnode=coins.prohashing.com:6002
+  litecoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        addnode=coins.prohashing.com:6001
+  viacoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        addnode=coins.prohashing.com:6095
+  monacoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        addnode=coins.prohashing.com:6138
+exclusive:
+  - addnode

--- a/docker-compose-generator/docker-fragments/opt-more-memory.yml
+++ b/docker-compose-generator/docker-fragments/opt-more-memory.yml
@@ -12,7 +12,7 @@ services:
         dbcache=1024
   dogecoind:
     environment:
-      BITCOIN_EXTRA_ARGS: |
+      DOGECOIN_EXTRA_ARGS: |
         dbcache=1024
   feathercoind:
     environment:

--- a/docker-compose-generator/docker-fragments/opt-more-memory.yml
+++ b/docker-compose-generator/docker-fragments/opt-more-memory.yml
@@ -10,6 +10,10 @@ services:
     environment:
       BITCOIN_EXTRA_ARGS: |
         dbcache=1024
+  dogecoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=1024
   feathercoind:
     environment:
       BITCOIN_EXTRA_ARGS: |

--- a/docker-compose-generator/docker-fragments/opt-more-memory.yml
+++ b/docker-compose-generator/docker-fragments/opt-more-memory.yml
@@ -1,5 +1,5 @@
 version: "3"
-# If your machine has moar than 1GB of memory dedicated for bitcoind, use this
+# If your machine has more than 1GB of memory dedicated for bitcoind, use this
 
 services:
   bitcoind:

--- a/docker-compose-generator/docker-fragments/opt-save-memory.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-memory.yml
@@ -18,7 +18,7 @@ services:
         maxmempool=50
   dogecoind:
     environment:
-      BITCOIN_EXTRA_ARGS: |
+      DOGECOIN_EXTRA_ARGS: |
         dbcache=50
         maxmempool=50
   feathercoind:

--- a/docker-compose-generator/docker-fragments/opt-save-memory.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-memory.yml
@@ -16,6 +16,11 @@ services:
       BITCOIN_EXTRA_ARGS: |
         dbcache=50
         maxmempool=50
+  dogecoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        dbcache=50
+        maxmempool=50
   feathercoind:
     environment:
       BITCOIN_EXTRA_ARGS: |


### PR DESCRIPTION
DOGE is the only coin in BPS that uses a static rpcuser= and rpcpassword= that shouldn't be there.  
        rpcuser=ceiwHEbqWI83
        rpcpassword=DwubwWsoo3
is fair game for anyone to easily hack a new users node.

-Added unique rpcuser and rpcpassword generation for DOGE
-Removed static dbcache=50 so that the memory fragments will work properly (more-memory and save-memory)
-Addnodes fragment added using Prohashing explorer for eligable coins
-More memory and save memory now DOGE compatible
-Fixed spelling error 
