### PR TITLE
Separate default liquid prune to own fragment

### DIFF
--- a/docker-compose-generator/docker-fragments/liquid-default-prune.yml
+++ b/docker-compose-generator/docker-fragments/liquid-default-prune.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+services:
+  elementsd_liquid:
+    environment:
+      ELEMENTS_EXTRA_ARGS: |
+        prune=5000

--- a/docker-compose-generator/docker-fragments/liquid.yml
+++ b/docker-compose-generator/docker-fragments/liquid.yml
@@ -16,7 +16,6 @@ services:
         port=39388
         whitelist=0.0.0.0/0
         validatepegin=0
-        prune=5000
         fallbackfee=0.000001
     expose:
       - "43782"
@@ -40,3 +39,6 @@ services:
 volumes:
   elements_datadir:
   elements_wallet_datadir:
+
+recommended:
+  - "liquid-default-prune"


### PR DESCRIPTION
This allows users who dont want to prune their liquid node to exclude the pruning fragment. (allows rescanning for utxos)