### PR TITLE
Add Sphinx Relay opt fragment

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -93,7 +93,17 @@
 		proxy_pass http://btctransmuter;
 	}
 		{{ end }}
-		
+
+  {{ if (eq $serviceName "sphinxrelay") }}
+  location /sphinxrelay/ {
+    proxy_set_header        Host               $host;
+    proxy_set_header        X-Real-IP          $remote_addr;
+    proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto  $scheme;
+    proxy_pass http://sphinxrelay:3300/;
+  }
+  {{ end }}
+
 		{{ if (eq $serviceName "configurator") }}
 	location /configurator/ {
 		proxy_set_header Connection "";

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ We are trying to update our dependencies to run on `arm32v7` and `x64` boards. H
 | traefik | latest | [✔️](https://raw.githubusercontent.com/containous/traefik-library-image/master/scratch/Dockerfile) | ️❌ | ️❌ | [Github](https://github.com/containous/traefik-library-image) - [DockerHub](https://hub.docker.com/_/traefik) |
 | chekaz/docker-trezarcoin | 0.13.0 | [✔️](https://raw.githubusercontent.com/ChekaZ/docker/master/trezarcoin/1.2.0/Dockerfile) | ️❌ | ️❌ | [Github](https://github.com/ChekaZ/docker) - [DockerHub](https://hub.docker.com/r/chekaz/docker-trezarcoin) |
 | romanornr/docker-viacoin | 0.15.2 | [✔️](https://raw.githubusercontent.com/viacoin/docker-viacoin/master/viacoin/0.15.2/docker-viacoin) | ️❌ | ️❌ | [Github](https://github.com/viacoin/docker-viacoin) - [DockerHub](https://hub.docker.com/r/romanornr/docker-viacoin) |
+| stakwork/sphinx-relay | 2.0.12 | [✔️](https://github.com/stakwork/sphinx-relay/blob/v2.0.12/Dockerfile) | ❌ | ❌ | [Github](https://github.com/stakwork/sphinx-relay) - [DockerHub](https://hub.docker.com/r/sphinxlightning/sphinx-relay/) |
 
 # FAQ
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Available `BTCPAYGEN_ADDITIONAL_FRAGMENTS` currently are:
 * [opt-add-configurator](docker-compose-generator/docker-fragments/opt-add-configurator.yml), to integrate the [BTCPay Server Configurator](https://install.btcpayserver.org) to manage your BTCPay deployment through a UI, and to allow new deployments elsewhere easily.
 * [opt-add-pihole](docker-compose-generator/docker-fragments/opt-add-pihole.yml) ([See the documentation](docs/pihole.md))
 * [opt-add-ndlc](docker-compose-generator/docker-fragments/opt-add-ndlc.yml) ([See the documentation](docs/ndlc.md))
+* [opt-add-sphinxrelay](docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml) for [Sphinx Relay](https://github.com/stakwork/sphinx-relay). Maintained by [dennisreimann](https://github.com/dennisreimann).
 * [opt-add-thunderhub](docker-compose-generator/docker-fragments/opt-add-thunderhub.yml) for a LND Lightning Node Manager in your Browser. Maintained by [apotdevin](https://github.com/apotdevin).
 * [opt-add-teos](docker-compose-generator/docker-fragments/opt-add-teos.yml) for [The Eye Of Satoshi](https://github.com/talaia-labs/python-teos), a BOLT13 Lightning Watchtower. Use port 9814 on your server or Tor to connect.
 * [opt-add-zammad](docker-compose-generator/docker-fragments/opt-add-zammad.yml) for [Zammad](https://zammad.com/features), a web based open source helpdesk/customer support system with many features to manage customer communication via several channels like telephone, facebook, twitter, chat and e-mails

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ We are trying to update our dependencies to run on `arm32v7` and `x64` boards. H
 | traefik | latest | [✔️](https://raw.githubusercontent.com/containous/traefik-library-image/master/scratch/Dockerfile) | ️❌ | ️❌ | [Github](https://github.com/containous/traefik-library-image) - [DockerHub](https://hub.docker.com/_/traefik) |
 | chekaz/docker-trezarcoin | 0.13.0 | [✔️](https://raw.githubusercontent.com/ChekaZ/docker/master/trezarcoin/1.2.0/Dockerfile) | ️❌ | ️❌ | [Github](https://github.com/ChekaZ/docker) - [DockerHub](https://hub.docker.com/r/chekaz/docker-trezarcoin) |
 | romanornr/docker-viacoin | 0.15.2 | [✔️](https://raw.githubusercontent.com/viacoin/docker-viacoin/master/viacoin/0.15.2/docker-viacoin) | ️❌ | ️❌ | [Github](https://github.com/viacoin/docker-viacoin) - [DockerHub](https://hub.docker.com/r/romanornr/docker-viacoin) |
-| stakwork/sphinx-relay | 2.0.12 | [✔️](https://github.com/stakwork/sphinx-relay/blob/v2.0.12/Dockerfile) | ❌ | ❌ | [Github](https://github.com/stakwork/sphinx-relay) - [DockerHub](https://hub.docker.com/r/sphinxlightning/sphinx-relay/) |
+| stakwork/sphinx-relay | 2.0.13 | [✔️](https://github.com/stakwork/sphinx-relay/blob/v2.0.13/Dockerfile) | ❌ | ❌ | [Github](https://github.com/stakwork/sphinx-relay) - [DockerHub](https://hub.docker.com/r/sphinxlightning/sphinx-relay/) |
 
 # FAQ
 

--- a/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
@@ -6,9 +6,6 @@ services:
     volumes:
       - "sphinxrelay_datadir:/etc/sphinxrelay_datadir"
   lnd_bitcoin:
-    environment:
-      LND_EXTRA_ARGS: |
-        accept-keysend=1
     expose:
       - "10009"
   sphinxrelay:
@@ -36,3 +33,4 @@ volumes:
   sphinxrelay_datadir:
 required:
   - "bitcoin-lnd"
+  - "opt-lnd-keysend"

--- a/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
@@ -2,14 +2,14 @@ version: "3"
 services:
   btcpayserver:
     environment:
-      BTCPAY_EXTERNALSERVICES: "Sphinx Relay:${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/sphinxrelay/;"
+      BTCPAY_EXTERNALSERVICES: "Sphinx Relay:${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/sphinxrelay/app;"
     volumes:
       - "sphinxrelay_datadir:/etc/sphinxrelay_datadir"
   lnd_bitcoin:
     expose:
       - "10009"
   sphinxrelay:
-    image: sphinxlightning/sphinx-relay:v2.0.8
+    image: sphinxlightning/sphinx-relay:v2.0.12
     user: "0:0"
     restart: unless-stopped
     expose:
@@ -19,11 +19,14 @@ services:
       - "lnd_bitcoin_datadir:/relay/lnd:ro"
     environment:
       NODE_ENV: production
-      NODE_IP: lnd_bitcoin
+      NODE_IP: ${BTCPAY_HOST}/sphinxrelay
+      NODE_ALIAS: ${LIGHTNING_ALIAS}
       LND_IP: lnd_bitcoin
       LND_PORT: 10009
       PORT: 3300
       MACAROON_LOCATION: /relay/lnd/admin.macaroon
+      ROUTER_MACAROON_LOCATION: /relay/lnd/data/chain/bitcoin/mainnet/router.macaroon
+      SIGNER_MACAROON_LOCATION: /relay/lnd/data/chain/bitcoin/mainnet/signer.macaroon
       TLS_LOCATION: /relay/lnd/tls.cert
       LND_LOG_LOCATION: /relay/lnd/logs/bitcoin/mainnet/lnd.log
       PUBLIC_URL: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/sphinxrelay/

--- a/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
@@ -16,7 +16,7 @@ services:
       - "3300"
     volumes:
       - "sphinxrelay_datadir:/relay/.lnd"
-      - "lnd_bitcoin_datadir:/relay/lnd"
+      - "lnd_bitcoin_datadir:/relay/lnd:ro"
     environment:
       NODE_ENV: production
       NODE_IP: lnd_bitcoin

--- a/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
@@ -1,0 +1,38 @@
+version: "3"
+services:
+  btcpayserver:
+    environment:
+      BTCPAY_EXTERNALSERVICES: "Sphinx Relay:${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/sphinxrelay/;"
+    volumes:
+      - "sphinxrelay_datadir:/etc/sphinxrelay_datadir"
+  lnd_bitcoin:
+    environment:
+      LND_EXTRA_ARGS: |
+        accept-keysend=1
+    expose:
+      - "10009"
+  sphinxrelay:
+    image: sphinxlightning/sphinx-relay:v2.0.8
+    user: "0:0"
+    restart: unless-stopped
+    expose:
+      - "3300"
+    volumes:
+      - "sphinxrelay_datadir:/relay/.lnd"
+      - "lnd_bitcoin_datadir:/relay/lnd"
+    environment:
+      NODE_ENV: production
+      NODE_IP: lnd_bitcoin
+      LND_IP: lnd_bitcoin
+      LND_PORT: 10009
+      PORT: 3300
+      MACAROON_LOCATION: /relay/lnd/admin.macaroon
+      TLS_LOCATION: /relay/lnd/tls.cert
+      LND_LOG_LOCATION: /relay/lnd/logs/bitcoin/mainnet/lnd.log
+      PUBLIC_URL: ${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/sphinxrelay/
+    links:
+      - lnd_bitcoin
+volumes:
+  sphinxrelay_datadir:
+required:
+  - "bitcoin-lnd"

--- a/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-sphinxrelay.yml
@@ -9,7 +9,7 @@ services:
     expose:
       - "10009"
   sphinxrelay:
-    image: sphinxlightning/sphinx-relay:v2.0.12
+    image: sphinxlightning/sphinx-relay:v2.0.13
     user: "0:0"
     restart: unless-stopped
     expose:


### PR DESCRIPTION
Integrates [Sphinx Relay](https://github.com/stakwork/sphinx-relay) – a Node.js wrapper around LND, handling connectivity and storage for [Sphinx Chat](https://sphinx.chat/). 
This will be a handy addition for e.g. podcasters, that can use this integration to host their own [tribe](https://tribes.sphinx.chat/) and earn sats by streaming their podcast.

Leverages their official Docker image and connects it with our LND. The `user: "0:0"` config is required, because their image runs with a separate user `node`, which cannot access the linked LND files – that's why we set the user to `root` as in our other containers. 

Sphinx uses keysend, that's why we need to require the opt as well.

## Testing

To test this PR while it isn't merged, you can deploy it as a [custom fragment](https://docs.btcpayserver.org/Docker/#how-can-i-customize-the-generated-docker-compose-file):

- SSH into your BTCPay Server and go to the main BTCPay Server directory (where the `btcpay-setup.sh` script is located)
- create the file `docker-compose-generator/docker-fragments/opt-add-sphinxrelay.custom.yml` with the content of `opt-add-sphinxrelay.yml`
- add the diff snippet from `Production/nginx.tmpl` to the `Production/nginx.tmpl` file on your server
- run the following commands:

```bash
export BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-add-sphinxrelay.custom"
. ./btcpay-setup.sh -i
````

Once the setup is done you can check the Sphinx log using `docker logs -f generated_sphinxrelay_1`.

You should see a log like this, which also give you a QR code to connect.

<img width="872" alt="sphinx" src="https://user-images.githubusercontent.com/886/113458513-c62b9800-9412-11eb-8a30-deda68656976.png">
