### PR TITLE
Revert "Bump Spark Wallet"

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin-clightning.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-clightning.yml
@@ -41,7 +41,7 @@ services:
       - clightning_bitcoin
 
   clightning_bitcoin_spark:
-    image: shesek/spark-wallet:0.2.17-standalone
+    image: shesek/spark-wallet:0.2.9-standalone
     restart: unless-stopped
     environment:
       NETWORK: ${NBITCOIN_NETWORK:-regtest}


### PR DESCRIPTION
Reverts btcpayserver/btcpayserver-docker#448

After the updates the spark url from services gives a 502 

```
docker logs -t -f generated_clightning_bitcoin_spark_1
2021-04-16T06:07:52.747873175Z nc: unix connect failed: Connection refused
```