### PR TITLE
Restart nginx-gen when btcpay-restart

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -147,6 +147,7 @@ btcpay_restart() {
     if ! [ $? -eq 0 ]; then
         docker-compose -f $BTCPAY_DOCKER_COMPOSE restart
     fi
+    docker restart nginx-gen
     popd > /dev/null
 }
 


### PR DESCRIPTION
Everyime I restart BTCPay via the UI or even just btcpay-restart, nginx will return a 502 error consistently until I restaart nginx-gen