### PR TITLE
Added "project-name" param so containers have better names

### DIFF
--- a/btcpay-setup.sh
+++ b/btcpay-setup.sh
@@ -550,7 +550,7 @@ cd "$(dirname $BTCPAY_ENV_FILE)"
 
 if $HAS_DOCKER && [[ ! -z "$OLD_BTCPAY_DOCKER_COMPOSE" ]] && [[ "$OLD_BTCPAY_DOCKER_COMPOSE" != "$BTCPAY_DOCKER_COMPOSE" ]]; then
     echo "Closing old docker-compose at $OLD_BTCPAY_DOCKER_COMPOSE..."
-    docker-compose -f "$OLD_BTCPAY_DOCKER_COMPOSE" down -t "${COMPOSE_HTTP_TIMEOUT:-180}"
+    docker-compose -p btcpayserver -f "$OLD_BTCPAY_DOCKER_COMPOSE" down -t "${COMPOSE_HTTP_TIMEOUT:-180}"
 fi
 
 if $START; then

--- a/contrib/FastSync/save-utxo-set.sh
+++ b/contrib/FastSync/save-utxo-set.sh
@@ -29,7 +29,7 @@ rm /var/lib/docker/volumes/generated_bitcoin_datadir/_data/utxo-snapshot-*
 # Run only bitcoind and connect to it
 SCRIPT="$(cat save-utxo-set-in-bitcoind.sh)"
 cd "`dirname $BTCPAY_ENV_FILE`"
-docker-compose -f $BTCPAY_DOCKER_COMPOSE run --rm -e "NBITCOIN_NETWORK=$NBITCOIN_NETWORK" bitcoind bash -c "$SCRIPT"
+docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE run --rm -e "NBITCOIN_NETWORK=$NBITCOIN_NETWORK" bitcoind bash -c "$SCRIPT"
 btcpay-up.sh
 
 echo "Calculating the hash of the tar file..."

--- a/helpers.sh
+++ b/helpers.sh
@@ -116,10 +116,10 @@ env | grep ^BWT_ >> $BTCPAY_ENV_FILE || true
 btcpay_up() {
     pushd . > /dev/null
     cd "$(dirname "$BTCPAY_ENV_FILE")"
-    docker-compose -f $BTCPAY_DOCKER_COMPOSE up --remove-orphans -d -t "${COMPOSE_HTTP_TIMEOUT:-180}"
+    docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE up --remove-orphans -d -t "${COMPOSE_HTTP_TIMEOUT:-180}"
     # Depending on docker-compose, either the timeout does not work, or "compose -d and --timeout cannot be combined"
     if ! [ $? -eq 0 ]; then
-        docker-compose -f $BTCPAY_DOCKER_COMPOSE up --remove-orphans -d
+        docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE up --remove-orphans -d
     fi
     popd > /dev/null
 }
@@ -127,17 +127,17 @@ btcpay_up() {
 btcpay_pull() {
     pushd . > /dev/null
     cd "$(dirname "$BTCPAY_ENV_FILE")"
-    docker-compose -f "$BTCPAY_DOCKER_COMPOSE" pull
+    docker-compose -p btcpayserver -f "$BTCPAY_DOCKER_COMPOSE" pull
     popd > /dev/null
 }
 
 btcpay_down() {
     pushd . > /dev/null
     cd "$(dirname "$BTCPAY_ENV_FILE")"
-    docker-compose -f $BTCPAY_DOCKER_COMPOSE down -t "${COMPOSE_HTTP_TIMEOUT:-180}"
+    docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE down -t "${COMPOSE_HTTP_TIMEOUT:-180}"
     # Depending on docker-compose, the timeout does not work.
     if ! [ $? -eq 0 ]; then
-        docker-compose -f $BTCPAY_DOCKER_COMPOSE down
+        docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE down
     fi
     popd > /dev/null
 }
@@ -145,10 +145,10 @@ btcpay_down() {
 btcpay_restart() {
     pushd . > /dev/null
     cd "$(dirname "$BTCPAY_ENV_FILE")"
-    docker-compose -f $BTCPAY_DOCKER_COMPOSE restart -t "${COMPOSE_HTTP_TIMEOUT:-180}"
+    docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE restart -t "${COMPOSE_HTTP_TIMEOUT:-180}"
     # Depending on docker-compose, the timeout does not work.
     if ! [ $? -eq 0 ]; then
-        docker-compose -f $BTCPAY_DOCKER_COMPOSE restart
+        docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE restart
     fi
     btcpay_up
     popd > /dev/null

--- a/ndlc-cli.sh
+++ b/ndlc-cli.sh
@@ -2,5 +2,5 @@
 
 pushd . > /dev/null
 cd "$(dirname "$BTCPAY_ENV_FILE")"
-docker-compose -f $BTCPAY_DOCKER_COMPOSE run --rm ndlc "$@"
+docker-compose -p btcpayserver -f $BTCPAY_DOCKER_COMPOSE run --rm ndlc "$@"
 popd > /dev/null


### PR DESCRIPTION
Containers won't have the `generated_` prefix anymore, but `btcpayserver_` instead. The `generated_` prefix comes from the dir name `Generated` where the docker-compose.yml is at and this is default behaviour.

WARNING: This can be tricky and maybe even dangerous if best practices were not followed. Let's discuss.

This change helps to find containers that are part of the BTCPay Server on a server that's running other apps as well.

All I did was add `-p btcpayserver` to all `docker-compose` commands.