### PR TITLE
C-Lightning REST: Enable access to all RPC commands

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin-clightning.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-clightning.yml
@@ -61,6 +61,7 @@ services:
       PROTOCOL: "http"
       NODE: clightning_bitcoin:9835
       LIGHTNINGD_READY_FILE: /root/.nbxplorer/btc_fully_synched
+      RPCCOMMANDS: "*"
     links:
       - clightning_bitcoin
     volumes:


### PR DESCRIPTION
The C-Lightning REST project allows access to all additional CLightning RPC commands by default: https://github.com/Ride-The-Lightning/c-lightning-REST#rpc

BTCPayServer-docker currently ships with this option disabled. However many useful RPC commands have not been wrapped by the REST project yet, so it is convenient to enable these by default.