### PR TITLE
Add Monero to opt-save-storage to run pruned node, default Monerod to full node

### DIFF
--- a/docker-compose-generator/docker-fragments/monero.yml
+++ b/docker-compose-generator/docker-fragments/monero.yml
@@ -5,7 +5,16 @@ services:
     restart: unless-stopped
     container_name: btcpayserver_monerod
     image: btcpayserver/monero:0.17.2.3
-    entrypoint: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
+    entrypoint: monerod 
+    environment:
+      MONERO_EXTRA_ARGS: |
+        rpc-bind-ip=0.0.0.0
+        confirm-external-bind=1
+        rpc-bind-port=18081
+        non-interactive=1
+        block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s"
+        hide-my-port=1
+        enable-dns-blocklist=1
     expose:
       - "18081"
     volumes:

--- a/docker-compose-generator/docker-fragments/opt-save-storage.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-storage.yml
@@ -21,6 +21,9 @@ services:
   litecoind:
     environment:
       BITCOIN_EXTRA_ARGS: prune=100000
+  monerod:
+    environment:
+      MONEROD_EXTRA_ARGS: prune-blockchain=1
   viacoind:
     environment:
       BITCOIN_EXTRA_ARGS: prune=100000

--- a/docker-compose-generator/docker-fragments/opt-save-storage.yml
+++ b/docker-compose-generator/docker-fragments/opt-save-storage.yml
@@ -23,7 +23,7 @@ services:
       BITCOIN_EXTRA_ARGS: prune=100000
   monerod:
     environment:
-      MONEROD_EXTRA_ARGS: prune-blockchain=1
+      MONERO_EXTRA_ARGS: prune-blockchain=1
   viacoind:
     environment:
       BITCOIN_EXTRA_ARGS: prune=100000


### PR DESCRIPTION
Resolves #557 

Also to note- this PR would change the default Monerod node fragment behavior from pruned to full (as it should be), and moves that config to opt-save-storage.yml via MONERO_EXTRA_ARGS.  Would appreciate it if someone can review.  