### PR TITLE
Fix error of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   cansetup:
     machine:
       enabled: true
+      image: ubuntu-2004:202101-01
     steps:
       - checkout
       - run:

--- a/.circleci/test-install.sh
+++ b/.circleci/test-install.sh
@@ -3,6 +3,7 @@
 set -e
 
 apt-get remove docker-ce
+rm -rf /usr/bin/docker
 rm -rf /usr/local/bin/docker-compose
 
 cd ../..


### PR DESCRIPTION
I use google translate, so probably I use strange english. Sorry.
The result of testing with this commit.
https://app.circleci.com/pipelines/github/wakiyamap/btcpayserver-docker/17/workflows/4ddd5318-87bb-49d3-9524-f43368443e9b/jobs/16

1. CircleCI use ubuntu 14.04. So `curl -fsSL https://get.docker.com -o get-docker.sh` is failed. This can use over 16.04.
https://discuss.circleci.com/t/default-machine-executor-image-update/29308
-> add `image: ubuntu-2004:202101-01`
You can specify a higher version, but docker-compose will give an error. Probably because the docker-compose used is 1.28.6.
https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

2. In this image, `apt remove docker-ce` will leave debris of docker.
As a result, even though docker is not working, I try to install `docker-compose` as if there is docker and it fails.
-> add `rm -rf /usr/bin/docker`