### PR TITLE
Unify formatting of nginx config (tabs vs. spaces)

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -1,146 +1,149 @@
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 {{ define "upstream" }}
-	{{ if .Address }}
-		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
-		{{ if and .Container.Node.ID .Address.HostPort }}
-	# {{ .Container.Node.Name }}/{{ .Container.Name }}
-	server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
-		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
-		{{ else if .Network }}
-	# {{ .Container.Name }}
-	server {{ .Network.IP }}:{{ .Address.Port }};
-		{{ end }}
-	{{ else if .Network }}
-	# {{ .Container.Name }}
-		{{ if .Network.IP }}
-	server {{ .Network.IP }} down;
-		{{ else }}
-	server 127.0.0.1 down;
-		{{ end }}
-	{{ end }}
-
+  {{ if .Address }}
+    {{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
+    {{ if and .Container.Node.ID .Address.HostPort }}
+  # {{ .Container.Node.Name }}/{{ .Container.Name }}
+  server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
+    {{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
+    {{ else if .Network }}
+  # {{ .Container.Name }}
+  server {{ .Network.IP }}:{{ .Address.Port }};
+    {{ end }}
+  {{ else if .Network }}
+  # {{ .Container.Name }}
+    {{ if .Network.IP }}
+  server {{ .Network.IP }} down;
+    {{ else }}
+  server 127.0.0.1 down;
+    {{ end }}
+  {{ end }}
 {{ end }}
 
 {{ define "redirects" }}
-	{{ if eq $.HostName "btcpay" }}
-	{{ range $container := $.Containers }}
-		{{ $serviceName := (index $container.Labels "com.docker.compose.service") }}
-		{{ if (eq $serviceName "lnd_bitcoin") }}
-	location /lnrpc {
-		grpc_pass grpcs://lnd_bitcoin:10009;
-	}
-	location /lnd-rest/btc/ {
-		rewrite ^/lnd-rest/btc/(.*) /$1 break;
-		proxy_pass http://lnd_bitcoin:8080/;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "bitcoin_rtl") }}
-	location /rtl/ {
-		proxy_pass http://bitcoin_rtl:3000/rtl/;
-	}
-		{{ end }}
+  {{ if eq $.HostName "btcpay" }}
+  {{ range $container := $.Containers }}
+  {{ $serviceName := (index $container.Labels "com.docker.compose.service") }}
+  {{ if (eq $serviceName "lnd_bitcoin") }}
+  location /lnrpc {
+    grpc_pass grpcs://lnd_bitcoin:10009;
+  }
 
-		{{ if (eq $serviceName "joinmarket") }}
-		location /obwatch/ {
-		proxy_pass http://joinmarket:62601/;
-		}
-		{{ end }}
+  location /lnd-rest/btc/ {
+    rewrite ^/lnd-rest/btc/(.*) /$1 break;
+    proxy_pass http://lnd_bitcoin:8080/;
+  }
+  {{ end }}
 
-		{{ if (eq $serviceName "bitcoin_thub") }}
-	location /thub {
-		proxy_pass http://bitcoin_thub:3000/thub;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "btcqbo") }}
-	location /btcqbo/ {
-		proxy_pass http://btcqbo:8001;
-		proxy_redirect off;
-		proxy_set_header Host $host;
-		proxy_set_header X-Real-IP $remote_addr;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "clightning_bitcoin_spark") }}
-	location /spark/btc/ {
-		proxy_pass http://clightning_bitcoin_spark:9737/;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "clightning_bitcoin_charge") }}
-	location /lightning-charge/btc/ {
-		proxy_pass http://clightning_bitcoin_charge:9112/;
-	}
-	{{ end }}
-	{{ if (eq $serviceName "clightning_bitcoin_rest") }}
-	location /clightning-rest/btc/ {
-	    rewrite ^/clightning-rest/btc/(.*) /$1 break;
-		proxy_pass http://clightning_bitcoin_rest:3001/;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "clightning_groestlcoin_spark") }}
-	location /spark/grs/ {
-		proxy_pass http://clightning_groestlcoin_spark:9739/;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "clightning_groestlcoin_charge") }}
-	location /lightning-charge/grs/ {
-		proxy_pass http://clightning_groestlcoin_charge:9112/;
-	}
-		{{ end }}
+  {{ if (eq $serviceName "bitcoin_rtl") }}
+  location /rtl/ {
+    proxy_pass http://bitcoin_rtl:3000/rtl/;
+  }
+  {{ end }}
 
-		{{ if (eq $serviceName "btctransmuter") }}
-	location /btctransmuter/ {
-		proxy_set_header Connection "";
-		proxy_set_header        Host               $host;
-        proxy_set_header        X-Real-IP          $remote_addr;
-        proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Host   $host:443;
-        proxy_set_header        X-Forwarded-Server $host;
-        proxy_set_header        X-Forwarded-Port   443;
-        proxy_set_header        X-Forwarded-Proto  https;
-		proxy_pass http://btctransmuter;
-	}
-		{{ end }}
+  {{ if (eq $serviceName "joinmarket") }}
+  location /obwatch/ {
+    proxy_pass http://joinmarket:62601/;
+  }
+  {{ end }}
 
-		{{ if (eq $serviceName "bluewallet_lndhub_app") }}
-	location /bluewallet_lndhub_app/ {
-		proxy_pass http://bluewallet_lndhub_app:3000/;
-        sub_filter 'href="../'  'href="/bluewallet_lndhub_app/';
-        sub_filter 'src="/'  'src="/bluewallet_lndhub_app/';
-        sub_filter_once off;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "helipad") }}
-	location /helipad/ {
-		proxy_set_header Connection "";
-		proxy_set_header        Host               $host;
-		proxy_set_header        X-Real-IP          $remote_addr;
-        proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Host   $host:443;
-        proxy_set_header        X-Forwarded-Server $host;
-        proxy_set_header        X-Forwarded-Port   443;
-        proxy_set_header        X-Forwarded-Proto  https;
+  {{ if (eq $serviceName "bitcoin_thub") }}
+  location /thub {
+    proxy_pass http://bitcoin_thub:3000/thub;
+  }
+  {{ end }}
 
-		sub_filter_once off;
-		sub_filter_types *;
+  {{ if (eq $serviceName "btcqbo") }}
+  location /btcqbo/ {
+    proxy_pass http://btcqbo:8001;
+    proxy_redirect off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+  {{ end }}
 
+  {{ if (eq $serviceName "clightning_bitcoin_spark") }}
+  location /spark/btc/ {
+    proxy_pass http://clightning_bitcoin_spark:9737/;
+  }
+  {{ end }}
 
+  {{ if (eq $serviceName "clightning_bitcoin_charge") }}
+  location /lightning-charge/btc/ {
+    proxy_pass http://clightning_bitcoin_charge:9112/;
+  }
+  {{ end }}
 
-		sub_filter 'src="/'  'src="/helipad/';
-		sub_filter 'href="/'  'href="/helipad/';
-		sub_filter '/image'  '/helipad/image';
-		sub_filter '/pew'  '/helipad/pew';
-		sub_filter '/boosts'  '/helipad/boosts';
-		proxy_pass http://helipad:2112/;
+  {{ if (eq $serviceName "clightning_bitcoin_rest") }}
+  location /clightning-rest/btc/ {
+    rewrite ^/clightning-rest/btc/(.*) /$1 break;
+    proxy_pass http://clightning_bitcoin_rest:3001/;
+  }
+  {{ end }}
 
-	}
-		{{ end }}
+  {{ if (eq $serviceName "clightning_groestlcoin_spark") }}
+  location /spark/grs/ {
+    proxy_pass http://clightning_groestlcoin_spark:9739/;
+  }
+  {{ end }}
+
+  {{ if (eq $serviceName "clightning_groestlcoin_charge") }}
+  location /lightning-charge/grs/ {
+    proxy_pass http://clightning_groestlcoin_charge:9112/;
+  }
+  {{ end }}
+
+  {{ if (eq $serviceName "btctransmuter") }}
+  location /btctransmuter/ {
+    proxy_set_header Connection "";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $host:443;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-Port 443;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_pass http://btctransmuter;
+  }
+  {{ end }}
+
+  {{ if (eq $serviceName "bluewallet_lndhub_app") }}
+  location /bluewallet_lndhub_app/ {
+    proxy_pass http://bluewallet_lndhub_app:3000/;
+    sub_filter 'href="../' 'href="/bluewallet_lndhub_app/';
+    sub_filter 'src="/' 'src="/bluewallet_lndhub_app/';
+    sub_filter_once off;
+  }
+  {{ end }}
+
+  {{ if (eq $serviceName "helipad") }}
+  location /helipad/ {
+    proxy_set_header Connection "";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host $host:443;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-Port 443;
+    proxy_set_header X-Forwarded-Proto https;
+    sub_filter_once off;
+    sub_filter_types *;
+    sub_filter 'src="/' 'src="/helipad/';
+    sub_filter 'href="/' 'href="/helipad/';
+    sub_filter '/image' '/helipad/image';
+    sub_filter '/pew' '/helipad/pew';
+    sub_filter '/boosts' '/helipad/boosts';
+    proxy_pass http://helipad:2112/;
+  }
+  {{ end }}
 
   {{ if (eq $serviceName "lnd_lit") }}
   location /lit {
-    proxy_set_header Host               $host;
-    proxy_set_header X-Real-IP          $remote_addr;
-    proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto  $scheme;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_pass http://lnd_lit:8080/;
   }
 
@@ -151,84 +154,85 @@
 
   {{ if (eq $serviceName "sphinxrelay") }}
   location /sphinxrelay/ {
-    proxy_set_header        Host               $host;
-    proxy_set_header        X-Real-IP          $remote_addr;
-    proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto  $scheme;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_pass http://sphinxrelay:3300/;
   }
   {{ end }}
 
   {{ if (eq $serviceName "tallycoin_connect") }}
   location /tallycoin-connect/ {
-    proxy_set_header        Host               $host;
-    proxy_set_header        X-Real-IP          $remote_addr;
-    proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto  $scheme;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_pass http://tallycoin_connect:8123/;
   }
   {{ end }}
 
-		{{ if (eq $serviceName "configurator") }}
-	location /configurator/ {
-		proxy_set_header Connection "";
-		proxy_set_header        Host               $host;
-        proxy_set_header        X-Real-IP          $remote_addr;
-        proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Host   $host:443;
-        proxy_set_header        X-Forwarded-Server $host;
-        proxy_set_header        X-Forwarded-Port   443;
-        proxy_set_header        X-Forwarded-Proto  https;
-		proxy_pass http://configurator;
-	}
-		{{ end }}
-		{{ if (eq $serviceName "nnostr-relay") }}
-	location /nostr/ {
-		proxy_set_header Connection "";
-		proxy_set_header        Host               $host;
-        proxy_set_header        X-Real-IP          $remote_addr;
-        proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
-        proxy_set_header        X-Forwarded-Host   $host:443;
-        proxy_set_header        X-Forwarded-Server $host;
-        proxy_set_header        X-Forwarded-Port   443;
-        proxy_set_header        X-Forwarded-Proto  https;
-		proxy_http_version 1.1;
-    	proxy_set_header Upgrade $http_upgrade;
-    	proxy_set_header Connection "Upgrade";
-		proxy_pass http://nnostr-relay;
-	}
-		{{ end }}
-	{{ end }}
-	{{ end }}
+  {{ if (eq $serviceName "configurator") }}
+  location /configurator/ {
+    proxy_set_header Connection "";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host   $host:443;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-Port   443;
+    proxy_set_header X-Forwarded-Proto  https;
+    proxy_pass http://configurator;
+  }
+  {{ end }}
 
-	{{ if eq $.HostName "librepatron" }}
-	{{ range $container := $.Containers }}
-		{{ $serviceName := (index $container.Labels "com.docker.compose.service") }}
-		{{ if (eq $serviceName "isso") }}
-	location /isso {
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Script-Name /isso;
-		proxy_set_header Host $host;
-		proxy_set_header X-Forwarded-Proto $scheme;
-		proxy_pass http://isso:8080;
-	}
-		{{ end }}
-	{{ end }}
-	{{ end }}
+  {{ if (eq $serviceName "nnostr-relay") }}
+  location /nostr/ {
+    proxy_set_header Connection "";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Host   $host:443;
+    proxy_set_header X-Forwarded-Server $host;
+    proxy_set_header X-Forwarded-Port   443;
+    proxy_set_header X-Forwarded-Proto  https;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_pass http://nnostr-relay;
+  }
+  {{ end }}
+  {{ end }}
+  {{ end }}
+
+  {{ if eq $.HostName "librepatron" }}
+  {{ range $container := $.Containers }}
+  {{ $serviceName := (index $container.Labels "com.docker.compose.service") }}
+  {{ if (eq $serviceName "isso") }}
+  location /isso {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Script-Name /isso;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://isso:8080;
+  }
+  {{ end }}
+  {{ end }}
+  {{ end }}
 {{ end }}
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
 # scheme used to connect to this server
 map $http_x_forwarded_proto $proxy_x_forwarded_proto {
   default $http_x_forwarded_proto;
-  ''      $scheme;
+  '' $scheme;
 }
 
 # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
 # server port the client connected to
 map $http_x_forwarded_port $proxy_x_forwarded_port {
   default $http_x_forwarded_port;
-  ''      $server_port;
+  '' $server_port;
 }
 
 # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
@@ -260,8 +264,8 @@ gzip_min_length 1000;
 gzip_types image/svg+xml text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
 log_format vhost '$host $remote_addr - $remote_user [$time_local] '
-                 '"$request" $status $body_bytes_sent '
-                 '"$http_referer" "$http_user_agent"';
+   '"$request" $status $body_bytes_sent '
+   '"$http_referer" "$http_user_agent"';
 
 access_log off;
 
@@ -284,8 +288,8 @@ proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
 proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
 
-proxy_buffer_size          128k;
-proxy_buffers              4 256k;
+proxy_buffer_size 128k;
+proxy_buffers     4 256k;
 proxy_busy_buffers_size    256k;
 client_header_buffer_size 500k;
 large_client_header_buffers 4 500k;
@@ -298,28 +302,28 @@ proxy_set_header Proxy "";
 
 {{ $enable_ipv6 := eq (or ($.Env.ENABLE_IPV6) "") "true" }}
 server {
-	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 80;
-	{{ if $enable_ipv6 }}
-	listen [::]:80;
-	{{ end }}
-	access_log /var/log/nginx/access.log vhost;
-	return 503;
+  server_name _; # This is just an invalid value which will never trigger on a real hostname.
+  listen 80;
+  {{ if $enable_ipv6 }}
+  listen [::]:80;
+  {{ end }}
+  access_log /var/log/nginx/access.log vhost;
+  return 503;
 }
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
-	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 443 ssl http2;
-	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2;
-	{{ end }}
-	access_log /var/log/nginx/access.log vhost;
-	return 503;
+  server_name _; # This is just an invalid value which will never trigger on a real hostname.
+  listen 443 ssl http2;
+  {{ if $enable_ipv6 }}
+  listen [::]:443 ssl http2;
+  {{ end }}
+  access_log /var/log/nginx/access.log vhost;
+  return 503;
 
-	ssl_session_tickets off;
-	ssl_certificate /etc/nginx/certs/default.crt;
-	ssl_certificate_key /etc/nginx/certs/default.key;
+  ssl_session_tickets off;
+  ssl_certificate /etc/nginx/certs/default.crt;
+  ssl_certificate_key /etc/nginx/certs/default.key;
 }
 {{ end }}
 
@@ -331,59 +335,59 @@ server {
 upstream {{ $upstream_name }} {
 
 {{ range $container := $containers }}
-	{{ $addrLen := len $container.Addresses }}
+  {{ $addrLen := len $container.Addresses }}
 
-	{{ range $knownNetwork := $CurrentContainer.Networks }}
-		{{ range $containerNetwork := $container.Networks }}
-			{{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
-	## Can be connected with "{{ $containerNetwork.Name }}" network
+  {{ range $knownNetwork := $CurrentContainer.Networks }}
+    {{ range $containerNetwork := $container.Networks }}
+      {{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
+  ## Can be connected with "{{ $containerNetwork.Name }}" network
 
-				{{/* If only 1 port exposed, use that */}}
-				{{ if eq $addrLen 1 }}
-					{{ $address := index $container.Addresses 0 }}
-					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
-				{{ else }}
-					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
-					{{ $address := where $container.Addresses "Port" $port | first }}
-					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-				{{ end }}
-			{{ else }}
-	# Cannot connect to network of this container
-	server 127.0.0.1 down;
-			{{ end }}
-		{{ end }}
-	{{ end }}
+        {{/* If only 1 port exposed, use that */}}
+        {{ if eq $addrLen 1 }}
+ {{ $address := index $container.Addresses 0 }}
+ {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+        {{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+        {{ else }}
+ {{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
+ {{ $address := where $container.Addresses "Port" $port | first }}
+ {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+        {{ end }}
+      {{ else }}
+  # Cannot connect to network of this container
+  server 127.0.0.1 down;
+      {{ end }}
+    {{ end }}
+  {{ end }}
 {{ end }}
 }
 
 {{ $hiddenReverseProxy := trim (or (first (groupByKeys $containers "Env.HIDDENSERVICE_REVERSEPROXY")) "") }}
 {{ if (eq $hiddenReverseProxy "nginx")}}
-	{{ $hiddenHostName := trim (or (first (groupByKeys $containers "Env.HIDDENSERVICE_NAME")) "") }}
-	{{ $onionHost := read (printf "/var/lib/tor/hidden_services/%s/hostname" $hiddenHostName) }}
-	{{ if ne $onionHost "" }}
+  {{ $hiddenHostName := trim (or (first (groupByKeys $containers "Env.HIDDENSERVICE_NAME")) "") }}
+  {{ $onionHost := read (printf "/var/lib/tor/hidden_services/%s/hostname" $hiddenHostName) }}
+  {{ if ne $onionHost "" }}
 server {
-	server_name {{ trim $onionHost }};
-	listen 80 ;
-	proxy_set_header X-Forwarded-Host  $http_host;
-	proxy_set_header Host $http_host;
-	proxy_set_header Upgrade $http_upgrade;
-	proxy_set_header Connection $proxy_connection;
-	proxy_set_header X-Real-IP $remote_addr;
-	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
-	proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
-	proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
-	access_log /var/log/nginx/access.log vhost;
-	{{ if (exists "/etc/nginx/vhost.d/default") }}
-	include /etc/nginx/vhost.d/default;
-	{{ end }}
-	location / {
-		proxy_pass http://{{ trim $upstream_name }};
-	}
-	{{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
+  server_name {{ trim $onionHost }};
+  listen 80 ;
+  proxy_set_header X-Forwarded-Host  $http_host;
+  proxy_set_header Host $http_host;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $proxy_connection;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+  proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
+  proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+  access_log /var/log/nginx/access.log vhost;
+  {{ if (exists "/etc/nginx/vhost.d/default") }}
+  include /etc/nginx/vhost.d/default;
+  {{ end }}
+  location / {
+    proxy_pass http://{{ trim $upstream_name }};
+  }
+  {{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
 }
-	{{ end }}
+  {{ end }}
 {{ end }}
 
 {{ range $host, $containers := groupByMulti $containers "Env.VIRTUAL_HOST" "," }}
@@ -415,15 +419,15 @@ server {
 
 {{ $cert := "" }}
 {{ if exists "/etc/nginx/certs" }}
-	{{/* Get the best matching cert  by name for the vhost. */}}
-	{{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host))}}
+  {{/* Get the best matching cert  by name for the vhost. */}}
+  {{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host))}}
 
-	{{/* vhostCert is actually a filename so remove any suffixes since they are added later */}}
-	{{ $vhostCert := trimSuffix ".crt" $vhostCert }}
-	{{ $vhostCert := trimSuffix ".key" $vhostCert }}
+  {{/* vhostCert is actually a filename so remove any suffixes since they are added later */}}
+  {{ $vhostCert := trimSuffix ".crt" $vhostCert }}
+  {{ $vhostCert := trimSuffix ".key" $vhostCert }}
 
-	{{/* Use the cert specified on the container or fallback to the best vhost match */}}
-	{{ $cert = (coalesce $certName $vhostCert) }}
+  {{/* Use the cert specified on the container or fallback to the best vhost match */}}
+  {{ $cert = (coalesce $certName $vhostCert) }}
 {{ end }}
 
 {{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
@@ -432,119 +436,119 @@ server {
 
 {{ if eq $https_method "redirect" }}
 server {
-	server_name {{ $host }};
-	listen 80 {{ $default_server }};
-	{{ if $enable_ipv6 }}
-	listen [::]:80 {{ $default_server }};
-	{{ end }}
-	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host$request_uri;
+  server_name {{ $host }};
+  listen 80 {{ $default_server }};
+  {{ if $enable_ipv6 }}
+  listen [::]:80 {{ $default_server }};
+  {{ end }}
+  access_log /var/log/nginx/access.log vhost;
+  return 301 https://$host$request_uri;
 }
 {{ end }}
 
 server {
-	proxy_set_header X-Forwarded-Host  $http_host;
-	proxy_set_header Host $http_host;
-	proxy_set_header Upgrade $http_upgrade;
-	proxy_set_header Connection $proxy_connection;
-	proxy_set_header X-Real-IP $remote_addr;
-	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
-	proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
-	proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
-	client_max_body_size 100M;
-	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
-	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2 {{ $default_server }};
-	{{ end }}
-	access_log /var/log/nginx/access.log vhost;
+  proxy_set_header X-Forwarded-Host  $http_host;
+  proxy_set_header Host $http_host;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $proxy_connection;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+  proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
+  proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+  client_max_body_size 100M;
+  server_name {{ $host }};
+  listen 443 ssl http2 {{ $default_server }};
+  {{ if $enable_ipv6 }}
+  listen [::]:443 ssl http2 {{ $default_server }};
+  {{ end }}
+  access_log /var/log/nginx/access.log vhost;
 
-	{{ if eq $network_tag "internal" }}
-	# Only allow traffic from internal clients
-	include /etc/nginx/network_internal.conf;
-	{{ end }}
+  {{ if eq $network_tag "internal" }}
+  # Only allow traffic from internal clients
+  include /etc/nginx/network_internal.conf;
+  {{ end }}
 
-	{{ if eq $ssl_policy "Mozilla-Modern" }}
-	ssl_protocols TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-	{{ else if eq $ssl_policy "Mozilla-Intermediate" }}
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
-	{{ else if eq $ssl_policy "Mozilla-Old" }}
-	ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:DES-CBC3-SHA:HIGH:SEED:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!RSAPSK:!aDH:!aECDH:!EDH-DSS-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!SRP';
-	{{ else if eq $ssl_policy "AWS-TLS-1-2-2017-01" }}
-	ssl_protocols TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256';
-	{{ else if eq $ssl_policy "AWS-TLS-1-1-2017-01" }}
-	ssl_protocols TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
-	{{ else if eq $ssl_policy "AWS-2016-08" }}
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
-	{{ else if eq $ssl_policy "AWS-2015-05" }}
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DES-CBC3-SHA';
-	{{ else if eq $ssl_policy "AWS-2015-03" }}
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA:DES-CBC3-SHA';
-	{{ else if eq $ssl_policy "AWS-2015-02" }}
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA';
-	{{ end }}
+  {{ if eq $ssl_policy "Mozilla-Modern" }}
+  ssl_protocols TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+  {{ else if eq $ssl_policy "Mozilla-Intermediate" }}
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
+  {{ else if eq $ssl_policy "Mozilla-Old" }}
+  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:DES-CBC3-SHA:HIGH:SEED:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!RSAPSK:!aDH:!aECDH:!EDH-DSS-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!SRP';
+  {{ else if eq $ssl_policy "AWS-TLS-1-2-2017-01" }}
+  ssl_protocols TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256';
+  {{ else if eq $ssl_policy "AWS-TLS-1-1-2017-01" }}
+  ssl_protocols TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+  {{ else if eq $ssl_policy "AWS-2016-08" }}
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+  {{ else if eq $ssl_policy "AWS-2015-05" }}
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DES-CBC3-SHA';
+  {{ else if eq $ssl_policy "AWS-2015-03" }}
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA:DES-CBC3-SHA';
+  {{ else if eq $ssl_policy "AWS-2015-02" }}
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA';
+  {{ end }}
 
-	ssl_prefer_server_ciphers on;
-	ssl_session_timeout 5m;
-	ssl_session_cache shared:SSL:50m;
-	ssl_session_tickets off;
+  ssl_prefer_server_ciphers on;
+  ssl_session_timeout 5m;
+  ssl_session_cache shared:SSL:50m;
+  ssl_session_tickets off;
 
-	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
-	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
+  ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
+  ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
 
-	{{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
-	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
-	{{ end }}
+  {{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
+  ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
+  {{ end }}
 
-	{{ if (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert)) }}
-	ssl_stapling on;
-	ssl_stapling_verify on;
-	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
-	{{ end }}
+  {{ if (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert)) }}
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
+  {{ end }}
 
-	{{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}
-	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
-	{{ end }}
+  {{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}
+  add_header Strict-Transport-Security "{{ trim $hsts }}" always;
+  {{ end }}
 
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
-	{{ else if (exists "/etc/nginx/vhost.d/default") }}
-	include /etc/nginx/vhost.d/default;
-	{{ end }}
+  {{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+  include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+  {{ else if (exists "/etc/nginx/vhost.d/default") }}
+  include /etc/nginx/vhost.d/default;
+  {{ end }}
 
-	location / {
-		{{ if eq $proto "uwsgi" }}
-		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ else if eq $proto "fastcgi" }}
-		root   {{ trim $vhost_root }};
-		include fastcgi.conf;
-		fastcgi_pass {{ trim $upstream_name }};
-		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ end }}
+  location / {
+    {{ if eq $proto "uwsgi" }}
+    include uwsgi_params;
+    uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+    {{ else if eq $proto "fastcgi" }}
+    root   {{ trim $vhost_root }};
+    include fastcgi.conf;
+    fastcgi_pass {{ trim $upstream_name }};
+    {{ else }}
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+    {{ end }}
 
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-		include /etc/nginx/vhost.d/default_location;
-		{{ end }}
-	}
-	{{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
+    {{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+    auth_basic	"Restricted {{ $host }}";
+    auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+    {{ end }}
+    {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+    include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+    {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+    include /etc/nginx/vhost.d/default_location;
+    {{ end }}
+  }
+  {{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
 }
 
 {{ end }}
@@ -552,97 +556,97 @@ server {
 {{ if or (not $is_https) (eq $https_method "noredirect") }}
 
 server {
-	server_name {{ $host }};
-	listen 80 {{ $default_server }};
-	{{ if $enable_ipv6 }}
-	listen [::]:80 {{ $default_server }};
-	{{ end }}
-	access_log /var/log/nginx/access.log vhost;
+  server_name {{ $host }};
+  listen 80 {{ $default_server }};
+  {{ if $enable_ipv6 }}
+  listen [::]:80 {{ $default_server }};
+  {{ end }}
+  access_log /var/log/nginx/access.log vhost;
 
-	{{ if eq $network_tag "internal" }}
-	# Only allow traffic from internal clients
-	include /etc/nginx/network_internal.conf;
-	{{ end }}
+  {{ if eq $network_tag "internal" }}
+  # Only allow traffic from internal clients
+  include /etc/nginx/network_internal.conf;
+  {{ end }}
 
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
-	{{ else if (exists "/etc/nginx/vhost.d/default") }}
-	include /etc/nginx/vhost.d/default;
-	{{ end }}
+  {{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+  include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+  {{ else if (exists "/etc/nginx/vhost.d/default") }}
+  include /etc/nginx/vhost.d/default;
+  {{ end }}
 
-	location / {
-		{{ if eq $proto "uwsgi" }}
-		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ else if eq $proto "fastcgi" }}
-		root   {{ trim $vhost_root }};
-		include fastcgi.conf;
-		fastcgi_pass {{ trim $upstream_name }};
-		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-		include /etc/nginx/vhost.d/default_location;
-		{{ end }}
-	}
-	{{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
+  location / {
+    {{ if eq $proto "uwsgi" }}
+    include uwsgi_params;
+    uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+    {{ else if eq $proto "fastcgi" }}
+    root   {{ trim $vhost_root }};
+    include fastcgi.conf;
+    fastcgi_pass {{ trim $upstream_name }};
+    {{ else }}
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+    {{ end }}
+    {{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+    auth_basic	"Restricted {{ $host }}";
+    auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+    {{ end }}
+    {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+    include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+    {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+    include /etc/nginx/vhost.d/default_location;
+    {{ end }}
+  }
+  {{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
 }
 
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
-	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
-	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2 {{ $default_server }};
-	{{ end }}
-	access_log /var/log/nginx/access.log vhost;
-	{{/* Enable usage of self-signed SSL certificate if .local hostname */}}
-	{{ if hasSuffix "local" $host }}
-	{{ if eq $network_tag "internal" }}
-	# Only allow traffic from internal clients
-	include /etc/nginx/network_internal.conf;
-	{{ end }}
+  server_name {{ $host }};
+  listen 443 ssl http2 {{ $default_server }};
+  {{ if $enable_ipv6 }}
+  listen [::]:443 ssl http2 {{ $default_server }};
+  {{ end }}
+  access_log /var/log/nginx/access.log vhost;
+  {{/* Enable usage of self-signed SSL certificate if .local hostname */}}
+  {{ if hasSuffix "local" $host }}
+  {{ if eq $network_tag "internal" }}
+  # Only allow traffic from internal clients
+  include /etc/nginx/network_internal.conf;
+  {{ end }}
 
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
-	{{ else if (exists "/etc/nginx/vhost.d/default") }}
-	include /etc/nginx/vhost.d/default;
-	{{ end }}
+  {{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+  include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+  {{ else if (exists "/etc/nginx/vhost.d/default") }}
+  include /etc/nginx/vhost.d/default;
+  {{ end }}
 
-	location / {
-		{{ if eq $proto "uwsgi" }}
-		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ else if eq $proto "fastcgi" }}
-		root   {{ trim $vhost_root }};
-		include fastcgi.conf;
-		fastcgi_pass {{ trim $upstream_name }};
-		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-		include /etc/nginx/vhost.d/default_location;
-		{{ end }}
-	}
-	{{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
-	{{ else }}
-	return 500;
-	{{ end }}
+  location / {
+    {{ if eq $proto "uwsgi" }}
+    include uwsgi_params;
+    uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+    {{ else if eq $proto "fastcgi" }}
+    root   {{ trim $vhost_root }};
+    include fastcgi.conf;
+    fastcgi_pass {{ trim $upstream_name }};
+    {{ else }}
+    proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+    {{ end }}
+    {{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+    auth_basic	"Restricted {{ $host }}";
+    auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+    {{ end }}
+    {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+    include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+    {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+    include /etc/nginx/vhost.d/default_location;
+    {{ end }}
+  }
+  {{ template "redirects" (dict "HostName" $host_name "Containers" $) }}
+  {{ else }}
+  return 500;
+  {{ end }}
 
-	ssl_certificate /etc/nginx/certs/default.crt;
-	ssl_certificate_key /etc/nginx/certs/default.key;
+  ssl_certificate /etc/nginx/certs/default.crt;
+  ssl_certificate_key /etc/nginx/certs/default.key;
 }
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Consistently use two spaces for indentation. Clean up minor inconsistencies across the services config blocks.