### PR TITLE
Fixes "line 30: exec: btcpay-update.sh: not found"

### DIFF
--- a/btcpay-update.sh
+++ b/btcpay-update.sh
@@ -27,7 +27,7 @@ cd "$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
 
 if [[ "$1" != "--skip-git-pull" ]]; then
     git pull --force
-    exec "btcpay-update.sh" --skip-git-pull
+    exec "./btcpay-update.sh" --skip-git-pull
     return
 fi
 


### PR DESCRIPTION
Fixes "./btcpay-update.sh: line 30: exec: btcpay-update.sh: not found" when running ./btcpay-update.sh