### PR TITLE
Backup and restore process

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -52,7 +52,7 @@ esac
 volumes_dir=/var/lib/docker/volumes
 backup_dir="$volumes_dir/backup_datadir"
 filename="backup.tar.gz"
-dumpname="postgres.sql"
+dumpname="postgres.sql.gz"
 
 if [ "$BACKUP_TIMESTAMP" == true ]; then
   timestamp=$(date "+%Y%m%d-%H%M%S")

--- a/backup.sh
+++ b/backup.sh
@@ -30,7 +30,7 @@ case "$BACKUP_PROVIDER" in
         echo -e "\033[0;31mSet S3_BUCKET environment variable and try again.\033[0m"
         exit 1
     fi
-    
+
     if [ -z "$S3_PATH" ]; then
         echo -e "\033[1;33mUsing bucket root for backup, set S3_PATH if you want to backup into a specific folder (Make sure it ends with a trailing slash).\033[0m"
     fi
@@ -66,9 +66,14 @@ dbdump_path="$backup_dir/_data/${dumpname}"
 cd "$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
 . helpers.sh
 
+# ensure backup dir exists
+if [ ! -d "$backup_dir" ]; then
+    docker volume create backup_datadir
+fi
+
 # dump database
 echo "Dumping database …"
-btcpay_dump_db $dumpname
+btcpay_dump_db $dbdump_path
 
 if [[ "$1" == "--only-db" ]]; then
     tar -cvzf $backup_path $dbdump_path

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Please be aware of these important issues:
 #

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Please be aware of these important issues:
+#
+# - Old channel state is toxic and you can loose all your funds, if you or someone
+#   else closes a channel based on the backup with old state - and the state changes
+#   often! If you publish an old state (say from yesterday's backup) on chain, you
+#   WILL LOSE ALL YOUR FUNDS IN A CHANNEL, because the counterparty will publish a
+#   revocation key!
+
+if [ "$(id -u)" != "0" ]; then
+  echo "This script must be run as root."
+  echo "Use the command 'sudo su -' (include the trailing hypen) and try again"
+  exit 1
+fi
+
+# preparation
+docker_dir=/var/lib/docker
+dbdump_name=postgres.sql
+btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
+backup_dir="$docker_dir/volumes/backup_datadir/_data"
+dbdump_path="$docker_dir/$dbdump_name"
+backup_path="$backup_dir/backup.tar.gz"
+
+# ensure backup dir exists
+if [ ! -d "$backup_dir" ]; then
+  docker volume create backup_datadir
+fi
+
+cd $btcpay_dir
+. helpers.sh
+
+echo "Stopping BTCPay Server …"
+btcpay_down
+
+echo "Dumping database …"
+btcpay_dump_db $dbdump_path
+
+echo "Backing up files …"
+cd $docker_dir
+tar \
+  --exclude="volumes/backup_datadir" \
+  --exclude="volumes/generated_postgres_datadir" \
+  --exclude="volumes/generated_bitcoin_datadir" \
+  --exclude="volumes/generated_litecoin_datadir" \
+  --exclude="**/logs/*" \
+  -cvzf $backup_path $dbdump_name volumes/generated_*
+cd -
+
+echo "Restarting BTCPay Server …"
+btcpay_up
+
+echo "Cleaning up …"
+rm $dbdump_path
+
+echo "Backup done."

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -o pipefail -o errexit
+
 # Please be aware of these important issues:
 #
 # - Old channel state is toxic and you can loose all your funds, if you or someone
@@ -43,7 +45,7 @@ if [ -z "$dbcontainer" ]; then
 fi
 
 echo "Dumping database …"
-btcpay_dump_db $dbdump_path
+docker exec $dbcontainer pg_dumpall -c -U postgres | gzip > $dbdump_path
 
 echo "Stopping BTCPay Server …"
 btcpay_down

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -30,11 +30,23 @@ fi
 cd $btcpay_dir
 . helpers.sh
 
-echo "Stopping BTCPay Server …"
-btcpay_down
+dbcontainer=$(docker ps -a -q -f "name=postgres_1")
+if [ -z "$dbcontainer" ]; then
+  echo "Database container is not up and running. Starting BTCPay Server …"
+  btcpay_up
+
+  dbcontainer=$(docker ps -a -q -f "name=postgres_1")
+  if [ -z "$dbcontainer" ]; then
+    echo "Database container could not be started or found."
+    exit 1
+  fi
+fi
 
 echo "Dumping database …"
 btcpay_dump_db $dbdump_path
+
+echo "Stopping BTCPay Server …"
+btcpay_down
 
 echo "Backing up files …"
 cd $docker_dir

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -16,7 +16,7 @@ fi
 
 # preparation
 docker_dir=$(docker volume inspect generated_btcpay_datadir --format="{{.Mountpoint}}" | sed -e "s%/volumes/.*%%g")
-dbdump_name=postgres.sql
+dbdump_name=postgres.sql.gz
 btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
 backup_dir="$docker_dir/volumes/backup_datadir/_data"
 dbdump_path="$docker_dir/$dbdump_name"

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -26,7 +26,7 @@ backup_path="$backup_dir/backup.tar.gz"
 
 # ensure backup dir exists
 if [ ! -d "$backup_dir" ]; then
-  docker volume create backup_datadir
+  mkdir -p $backup_dir
 fi
 
 cd $btcpay_dir
@@ -36,7 +36,8 @@ dbcontainer=$(docker ps -a -q -f "name=postgres_1")
 if [ -z "$dbcontainer" ]; then
   printf "\n"
   echo "ℹ️  Database container is not up and running. Starting BTCPay Server …"
-  btcpay_up
+  docker volume create generated_postgres_datadir
+  docker-compose -f $BTCPAY_DOCKER_COMPOSE up -d postgres
 
   printf "\n"
   dbcontainer=$(docker ps -a -q -f "name=postgres_1")
@@ -84,17 +85,22 @@ echo "ℹ️  Archiving files in $(pwd)…"
       echo "✅ Encryption done."
     } || {
       echo "🚨  Encrypting failed. Please check the error message above."
-      # do not exit, we need to restart BTCPay Server
+      printf "\nℹ️  Restarting BTCPay Server …\n\n"
+      cd $btcpay_dir
+      btcpay_up
+      exit 1
     }
   fi
 } || {
   echo "🚨  Archiving failed. Please check the error message above."
-  # do not exit, we need to restart BTCPay Server
+  printf "\nℹ️  Restarting BTCPay Server …\n\n"
+  cd $btcpay_dir
+  btcpay_up
+  exit 1
 }
 
 printf "\nℹ️  Restarting BTCPay Server …\n\n"
-
-cd -
+cd $btcpay_dir
 btcpay_up
 
 printf "\nℹ️  Cleaning up …\n\n"

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -15,7 +15,7 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 # preparation
-docker_dir=/var/lib/docker
+docker_dir=$(docker volume inspect generated_btcpay_datadir --format="{{.Mountpoint}}" | sed -e "s%/volumes/.*%%g")
 dbdump_name=postgres.sql
 btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
 backup_dir="$docker_dir/volumes/backup_datadir/_data"

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -9,12 +9,12 @@ fi
 backup_file=$1
 if [ -z "$backup_file" ]; then
   echo "Usage: btcpay-restore.sh /path/to/backup.tar.gz"
-  exit
+  exit 1
 fi
 
 if [ ! -f "$backup_file" ]; then
   echo "$backup_file does not exist."
-  exit
+  exit 1
 fi
 
 volumes_dir=/var/lib/docker/volumes

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -17,8 +17,59 @@ if [ ! -f "$backup_file" ]; then
   exit 1
 fi
 
-volumes_dir=$(docker volume inspect generated_btcpay_datadir --format="{{.Mountpoint}}" | sed -e "s%/volumes/.*%%g")
-restore_dir="$volumes_dir/backup_datadir/_data/restore"
+# preparation
+docker_dir=$(docker volume inspect generated_btcpay_datadir --format="{{.Mountpoint}}" | sed -e "s%/volumes/.*%%g")
+restore_dir="$docker_dir/volumes/backup_datadir/_data/restore"
+dbdump_name=postgres.sql.gz
+btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
 
+# ensure clean restore dir
+rm -rf $restore_dir
 mkdir -p $restore_dir
+
+echo "Extracting files …"
+cd $restore_dir
 tar -xvf $backup_file -C $restore_dir
+
+# basic control checks
+if [ ! -f "$dbdump_name" ]; then
+  echo "$dbdump_name does not exist."
+  exit 1
+fi
+
+if [ ! -d "volumes" ]; then
+  echo "volumes directory does not exist."
+  exit 1
+fi
+
+cd $btcpay_dir
+. helpers.sh
+
+dbcontainer=$(docker ps -a -q -f "name=postgres_1")
+if [ -z "$dbcontainer" ]; then
+  echo "Database container is not up and running. Starting BTCPay Server …"
+  btcpay_up
+
+  dbcontainer=$(docker ps -a -q -f "name=postgres_1")
+  if [ -z "$dbcontainer" ]; then
+    echo "Database container could not be started or found."
+    exit 1
+  fi
+fi
+
+echo "Restoring database …"
+cd $restore_dir
+gunzip -c $dbdump_name | docker exec -i $dbcontainer psql -U postgres postgres -a
+
+# echo "Stopping BTCPay Server …"
+# btcpay_down
+
+# # TODO All the restore tasks :)
+
+# echo "Restarting BTCPay Server …"
+# btcpay_up
+
+echo "Cleaning up …"
+rm -rf $restore_dir
+
+echo "Restore done."

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -o pipefail -o errexit
+
 if [ "$(id -u)" != "0" ]; then
   echo "This script must be run as root."
   echo "Use the command 'sudo su -' (include the trailing hypen) and try again"

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 if [ "$(id -u)" != "0" ]; then
   echo "This script must be run as root."

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -17,7 +17,7 @@ if [ ! -f "$backup_file" ]; then
   exit 1
 fi
 
-volumes_dir=/var/lib/docker/volumes
+volumes_dir=$(docker volume inspect generated_btcpay_datadir --format="{{.Mountpoint}}" | sed -e "s%/volumes/.*%%g")
 restore_dir="$volumes_dir/backup_datadir/_data/restore"
 
 mkdir -p $restore_dir

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ "$(id -u)" != "0" ]; then
+  echo "This script must be run as root."
+  echo "Use the command 'sudo su -' (include the trailing hypen) and try again"
+  exit 1
+fi
+
+backup_file=$1
+if [ -z "$backup_file" ]; then
+  echo "Usage: btcpay-restore.sh /path/to/backup.tar.gz"
+  exit
+fi
+
+if [ ! -f "$backup_file" ]; then
+  echo "$backup_file does not exist."
+  exit
+fi
+
+volumes_dir=/var/lib/docker/volumes
+restore_dir="$volumes_dir/backup_datadir/_data/restore"
+
+mkdir -p $restore_dir
+tar -xvf $backup_file -C $restore_dir

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -49,6 +49,7 @@ if [[ "$backup_path" == *.gpg ]]; then
 fi
 
 cd $restore_dir
+
 echo "ℹ️  Extracting files in $(pwd) …"
 tar -xvf $backup_path -C $restore_dir
 
@@ -69,19 +70,45 @@ cd $btcpay_dir
 printf "\nℹ️  Stopping BTCPay Server …\n\n"
 btcpay_down
 
+cd $restore_dir
+
 {
-  printf "\nℹ️  Starting database container …"
+  printf "\nℹ️  Restoring volumes …\n"
+  # ensure volumes dir exists
+  if [ ! -d "$docker_dir/volumes" ]; then
+    mkdir -p $docker_dir/volumes
+  fi
+  # copy volume directories over
+  cp -r volumes/* $docker_dir/volumes/
+  # ensure datadirs excluded in backup exist
+  mkdir -p $docker_dir/volumes/generated_bitcoin_datadir/_data
+  mkdir -p $docker_dir/volumes/generated_litecoin_datadir/_data
+  mkdir -p $docker_dir/volumes/generated_postgres_datadir/_data
+  echo "✅ Volume restore done."
+} || {
+  echo "🚨  Restoring volumes failed. Please check the error message above."
+  printf "\nℹ️  Restarting BTCPay Server …\n\n"
+  cd $btcpay_dir
+  btcpay_up
+  exit 1
+}
+
+{
+  printf "\nℹ️  Starting database container …\n"
   docker-compose -f $BTCPAY_DOCKER_COMPOSE up -d postgres
+  sleep 10
   dbcontainer=$(docker ps -a -q -f "name=postgres")
   if [ -z "$dbcontainer" ]; then
     echo "🚨 Database container could not be started or found."
-    echo printf "\nℹ️  Restarting BTCPay Server …\n\n"
+    printf "\nℹ️  Restarting BTCPay Server …\n\n"
+    cd $btcpay_dir
     btcpay_up
     exit 1
   fi
 } || {
   echo "🚨  Starting database container failed. Please check the error message above."
-  echo printf "\nℹ️  Restarting BTCPay Server …\n\n"
+  printf "\nℹ️  Restarting BTCPay Server …\n\n"
+  cd $btcpay_dir
   btcpay_up
   exit 1
 }
@@ -91,16 +118,17 @@ cd $restore_dir
 {
   printf "\nℹ️  Restoring database …"
   gunzip -c $dbdump_name | docker exec -i $dbcontainer psql -U postgres postgres -a
+  echo "✅ Database restore done."
 } || {
   echo "🚨  Restoring database failed. Please check the error message above."
-  echo printf "\nℹ️  Restarting BTCPay Server …\n\n"
+  printf "\nℹ️  Restarting BTCPay Server …\n\n"
+  cd $btcpay_dir
   btcpay_up
   exit 1
 }
 
-# TODO Restore volumes
-
 printf "\nℹ️  Restarting BTCPay Server …\n\n"
+cd $btcpay_dir
 btcpay_up
 
 printf "\nℹ️  Cleaning up …\n\n"

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -3,19 +3,25 @@
 set -o pipefail -o errexit
 
 if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run as root."
-  echo "Use the command 'sudo su -' (include the trailing hypen) and try again"
+  printf "\n🚨 This script must be run as root.\n"
+  printf "➡️  Use the command 'sudo su -' (include the trailing hypen) and try again.\n\n"
   exit 1
 fi
 
-backup_file=$1
-if [ -z "$backup_file" ]; then
-  echo "Usage: btcpay-restore.sh /path/to/backup.tar.gz"
+backup_path=$1
+if [ -z "$backup_path" ]; then
+  printf "\nℹ️  Usage: btcpay-restore.sh /path/to/backup.tar.gz\n\n"
   exit 1
 fi
 
-if [ ! -f "$backup_file" ]; then
-  echo "$backup_file does not exist."
+if [ ! -f "$backup_path" ]; then
+  printf "\n🚨 $backup_path does not exist.\n\n"
+  exit 1
+fi
+
+if [[ "$backup_path" == *.gpg && -z "$BTCPAY_BACKUP_PASSPHRASE" ]]; then
+  printf "\n🔐 $backup_path is encrypted. Please provide the passphrase to decrypt it."
+  printf "\nℹ️  Usage: BTCPAY_BACKUP_PASSPHRASE=t0pSeCrEt btcpay-restore.sh /path/to/backup.tar.gz.gpg\n\n"
   exit 1
 fi
 
@@ -26,21 +32,35 @@ dbdump_name=postgres.sql.gz
 btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
 
 # ensure clean restore dir
+printf "\nℹ️  Cleaning restore directory $restore_dir …\n\n"
 rm -rf $restore_dir
 mkdir -p $restore_dir
 
-echo "Extracting files …"
+if [[ "$backup_path" == *.gpg ]]; then
+  echo "🔐 Decrypting backup file …"
+  {
+    gpg -o "${backup_path%.*}" --batch --yes --passphrase "$BTCPAY_BACKUP_PASSPHRASE" -d $backup_path
+    rm $backup_path
+    backup_path="${backup_path%.*}"
+    printf "✅ Decryption done.\n\n"
+  } || {
+    echo "🚨  Decryption failed. Please check the error message above."
+    exit 1
+  }
+fi
+
 cd $restore_dir
-tar -xvf $backup_file -C $restore_dir
+echo "ℹ️  Extracting files in $(pwd) …"
+tar -xvf $backup_path -C $restore_dir
 
 # basic control checks
 if [ ! -f "$dbdump_name" ]; then
-  echo "$dbdump_name does not exist."
+  printf "\n🚨 $dbdump_name does not exist.\n\n"
   exit 1
 fi
 
 if [ ! -d "volumes" ]; then
-  echo "volumes directory does not exist."
+  printf "\n🚨 volumes directory does not exist.\n\n"
   exit 1
 fi
 
@@ -49,29 +69,31 @@ cd $btcpay_dir
 
 dbcontainer=$(docker ps -a -q -f "name=postgres_1")
 if [ -z "$dbcontainer" ]; then
-  echo "Database container is not up and running. Starting BTCPay Server …"
+  printf "\n"
+  echo "ℹ️  Database container is not up and running. Starting BTCPay Server …"
   btcpay_up
 
+  printf "\n"
   dbcontainer=$(docker ps -a -q -f "name=postgres_1")
   if [ -z "$dbcontainer" ]; then
-    echo "Database container could not be started or found."
+    echo "🚨 Database container could not be started or found."
     exit 1
   fi
 fi
 
-echo "Restoring database …"
+printf "\nℹ️  Restoring database …"
 cd $restore_dir
 gunzip -c $dbdump_name | docker exec -i $dbcontainer psql -U postgres postgres -a
 
-# echo "Stopping BTCPay Server …"
+# printf "\nℹ️  Stopping BTCPay Server …\n\n"
 # btcpay_down
 
 # # TODO All the restore tasks :)
 
-# echo "Restarting BTCPay Server …"
+# echo printf "\nℹ️  Restarting BTCPay Server …\n\n"
 # btcpay_up
 
-echo "Cleaning up …"
-rm -rf $restore_dir
+printf "\nℹ️  Cleaning up …\n\n"
+rm -rf $restore_dir $backup_path
 
-echo "Restore done."
+printf "✅ Restore done\n\n"

--- a/helpers.sh
+++ b/helpers.sh
@@ -174,7 +174,7 @@ btcpay_restart() {
 btcpay_dump_db() {
     pushd . > /dev/null
     cd "$(dirname "$BTCPAY_ENV_FILE")"
-    local file_path=${1:-"postgres-$(date "+%Y%m%d-%H%M%S").sql"}
-    docker exec $(docker ps -a -q -f "name=postgres_1") pg_dumpall -c -U postgres > "$file_path"
+    local file_path=${1:-"postgres-$(date "+%Y%m%d-%H%M%S").sql.gz"}
+    docker exec $(docker ps -a -q -f "name=postgres_1") pg_dumpall -c -U postgres | gzip > "$file_path"
     popd > /dev/null
 }

--- a/helpers.sh
+++ b/helpers.sh
@@ -174,11 +174,7 @@ btcpay_restart() {
 btcpay_dump_db() {
     pushd . > /dev/null
     cd "$(dirname "$BTCPAY_ENV_FILE")"
-    backup_dir="/var/lib/docker/volumes/backup_datadir/_data"
-    if [ ! -d "$backup_dir" ]; then
-        docker volume create backup_datadir
-    fi
-    local filename=${1:-"postgres-$(date "+%Y%m%d-%H%M%S").sql"}
-    docker exec $(docker ps -a -q -f "name=postgres_1") pg_dumpall -c -U postgres > "$backup_dir/$filename"
+    local file_path=${1:-"postgres-$(date "+%Y%m%d-%H%M%S").sql"}
+    docker exec $(docker ps -a -q -f "name=postgres_1") pg_dumpall -c -U postgres > "$file_path"
     popd > /dev/null
 }


### PR DESCRIPTION
This is a fresh approach to backup and restore a BTCPay Server instance. The existing `backup.sh` script will stay (mostly) untouched and we are providing two new scripts:

- `btcpay-backup.sh`, which produces a `backup.tar.gz` file
- `btcpay-restore.sh`, which takes the path to the backup file and recreates the instance

We won't nail every aspect right away, so the goal of this PR is to provide a solid base which can then be extended in follow-up PRs. Right now, the script dumps the database to a `postgres.sql` file and backs it up together with the `volumes/generated_*` files (except the Bitcoin/Litecoin blockchain and Postgres directories).

## TODO

- [x] Let the backup script crash if something goes wrong instead of continuing like everything is fine
- [x] Use "docker volume inspect" to find the actual path of the volumes to back up instead of assuming they are in the standard dir. 
- [x]  (Optionally) [encrypt the backup](https://linuxconfig.org/how-to-create-compressed-encrypted-archives-with-tar-and-gpg) file for safe offsite storage using a passphrase and strong encryption (GPG / RSA)
- [x] Provide decent error messages when things go wrong.
- [x] Restore procedure
  - [x] Database should only be accessed by the restore process
  - [x] Handle existing data/folder (remove?) and recreate volumes
- [x] Document backup and restore
  - Tracked in btcpayserver/btcpayserver-doc#1116
  - Worked on in btcpayserver/btcpayserver-doc#1121

## Further ideas

- Also back up the `btcpayserver-docker` directory. 
- Also contain the project & tooling (so not just the data). This is important because an old backup may not work on newer code.
- Find a better or more appropriate way to backup the LN node static channel data
- The current `backup.sh` script does Dropbox uploads and such. Those things could be enabled here as well, but with a more modular approach, for instance by providing wrapper scripts for the new `btcpay-backup.sh`.

## Related issues

- Closes #628
- Closes #629 
- Closes #496
- Closes #249
- Closes #116 