### PR TITLE
Fix CI error(stop docker.socket)

### DIFF
--- a/.circleci/test-install.sh
+++ b/.circleci/test-install.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+systemctl stop docker.socket
 apt-get remove docker-ce
 rm -rf /usr/bin/docker
 rm -rf /usr/local/bin/docker-compose


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/wakiyamap/btcpayserver-docker?branch=master&filter=all
```
Warning: Stopping docker.service, but it can still be activated by:
  docker.socket
```
Perhaps `docker.socket` is doing something wrong.