### PR TITLE
Cloudflare-tunnel: Pass the original client's IP address to BTCPayServer

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -21,6 +21,7 @@
 
 {{ end }}
 
+
 {{ define "redirects" }}
 	{{ if eq $.HostName "btcpay" }}
 	{{ range $container := $.Containers }}
@@ -35,6 +36,12 @@
 		rewrite ^/lnd-rest/btc/(.*) /$1 break;
 		proxy_pass http://lnd_bitcoin:8080/;
 	}
+		{{ end }}
+		{{ if $container.Env.REAL_IP_HEADER }}
+		{{ range $containerNetwork := $container.Networks }}
+		set_real_ip_from {{ $containerNetwork.IP }};
+		{{ end }}
+        real_ip_header {{ $container.Env.REAL_IP_HEADER }};
 		{{ end }}
 		{{ if (eq $serviceName "bitcoin_rtl") }}
 	location /rtl/ {

--- a/docker-compose-generator/docker-fragments/opt-add-cloudflared.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-cloudflared.yml
@@ -4,6 +4,9 @@ services:
   cloudflared:
     container_name: 'cloudflared-tunnel'
     image: btcpayserver/cloudflared:2022.6.3
-    network_mode: host
     command: 'tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN}'
     restart: 'on-failure'
+    environment:
+      REAL_IP_HEADER: Cf-Connecting-Ip
+    links:
+      - nginx

--- a/docs/cloudflare-tunnel.md
+++ b/docs/cloudflare-tunnel.md
@@ -33,7 +33,7 @@ First we are going to create the tunnel on Cloudflare.
 5. In `Choose your environment`, click on docker and copy your token, you will need it later (the string after `--token`, as shown in the following screenshot)
 ![](./img/Cloudflare-Tunnel-Token.png)
 6. Click on the `Next` button
-7. Enter your subdomain, select your domain in the list. Then in `Service` select `HTTP` and enter `localhost`.
+7. Enter your subdomain, select your domain in the list. Then in `Service` select `HTTP` and enter `nginx`.
 8. In your the SSH session of your server, add cloudflare tunnel by running the following script. (replace `<YOUR_TOKEN_HERE>` by what you copied in step `5.`, and also replace `<YOUR_DOMAIN_HERE>` with the domain you entered in steps `7.`)
 ```bash
 BTCPAY_HOST="<YOUR_DOMAIN_HERE>"


### PR DESCRIPTION
Before this, BTCPay Server wasn't receiving the original IP address of clients. Meaning they would share the same bucket of anti spam protection. This would have made BTCPay emit TOO-MANY-REQUEST errors if too many users use it.

THIS IS A BREAKING CHANGE FOR YOUR TUNNEL!
You need to go to https://dash.teams.cloudflare.com/ , Tunnels then Configure, Click on Public Hostname tab, Edit and in Service, replace `localhost` by `nginx`.