### PR TITLE
Fix anonymous datadirs

### DIFF
--- a/docker-compose-generator/docker-fragments/monero.yml
+++ b/docker-compose-generator/docker-fragments/monero.yml
@@ -10,6 +10,7 @@ services:
       - "18081"
     volumes:
       - "xmr_data:/home/monero/.bitmonero"
+      - "xmr_wallet:/wallet"
   monerod_wallet:
     restart: unless-stopped
     container_name: btcpayserver_monero_wallet
@@ -18,6 +19,7 @@ services:
     expose:
       - "18082"
     volumes:
+      - "xmr_data:/home/monero/.bitmonero"
       - "xmr_wallet:/wallet"
     depends_on:
       - monerod

--- a/docker-compose-generator/docker-fragments/opt-add-lightning-terminal.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-lightning-terminal.yml
@@ -9,7 +9,7 @@ services:
     expose:
       - "8080"
     volumes:
-      - "lnd_lit_datadir:/root"
+      - "lnd_lit_datadir:/root/.lnd"
       - "lnd_bitcoin_datadir:/data/lnd:ro"
     links:
       - bitcoind


### PR DESCRIPTION
Uses the same folders as in the Dockerfiles to prevent the creation of anonymous volumes as [described here](https://stackoverflow.com/a/62654594/183537).

This should not be merged before someone running Monero in production has reviewed it. I'm not sure what the implications of these changes might be in case the containers/volumes already exist.