### PR TITLE
Update Monero image tag for multi-arch builds

### DIFF
--- a/docker-compose-generator/docker-fragments/monero.yml
+++ b/docker-compose-generator/docker-fragments/monero.yml
@@ -4,7 +4,7 @@ services:
   monerod:
     restart: unless-stopped
     container_name: btcpayserver_monerod
-    image: btcpayserver/monero:0.18.1.0-amd64
+    image: btcpayserver/monero:0.18.1.0
     entrypoint: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
     expose:
       - "18081"
@@ -13,7 +13,7 @@ services:
   monerod_wallet:
     restart: unless-stopped
     container_name: btcpayserver_monero_wallet
-    image: btcpayserver/monero:0.18.1.0-amd64
+    image: btcpayserver/monero:0.18.1.0
     entrypoint: monero-wallet-rpc --rpc-bind-ip=0.0.0.0 --disable-rpc-login --confirm-external-bind --rpc-bind-port=18082 --non-interactive --trusted-daemon  --daemon-address=monerod:18081 --wallet-file=/wallet/wallet --password-file=/wallet/password --tx-notify="/bin/sh ./scripts/notifier.sh  -X GET http://btcpayserver:49392/monerolikedaemoncallback/tx?cryptoCode=xmr&hash=%s"
     expose:
       - "18082"


### PR DESCRIPTION
Leverages working multi-arch builds after https://github.com/btcpayserver/dockerfile-deps/pull/48 is merged.