### PR TITLE
Backup: Exclude ElectrumX datadir and LND graph

### DIFF
--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -84,6 +84,8 @@ echo "ℹ️ Archiving files in $(pwd)…"
     --exclude="volumes/generated_litecoin_datadir/_data/chainstate" \
     --exclude="volumes/generated_litecoin_datadir/_data/debug.log" \
     --exclude="volumes/generated_postgres_datadir" \
+    --exclude="volumes/generated_electrumx_datadir" \
+    --exclude="volumes/generated_lnd_bitcoin_datadir/_data/data/graph" \
     --exclude="volumes/generated_clightning_bitcoin_datadir/_data/lightning-rpc" \
     --exclude="**/logs/*" \
     -cvzf $backup_path $dbdump_name volumes/generated_*


### PR DESCRIPTION
Both tend to grow very large and can be replicated in case of restore.