### PR TITLE
Exclude _data of coins; adding Liquid, Dash, Monero.

### DIFF
--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -96,14 +96,11 @@ echo "ℹ️ Archiving files in $(pwd)…"
 {
   tar \
     --exclude="volumes/backup_datadir" \
-    --exclude="volumes/generated_bitcoin_datadir/_data/blocks" \
-    --exclude="volumes/generated_bitcoin_datadir/_data/chainstate" \
-    --exclude="volumes/generated_bitcoin_datadir/_data/indexes" \
-    --exclude="volumes/generated_bitcoin_datadir/_data/debug.log" \
-    --exclude="volumes/generated_litecoin_datadir/_data/blocks" \
-    --exclude="volumes/generated_litecoin_datadir/_data/chainstate" \
-    --exclude="volumes/generated_litecoin_datadir/_data/indexes" \
-    --exclude="volumes/generated_litecoin_datadir/_data/debug.log" \
+    --exclude="volumes/generated_bitcoin_datadir/_data" \
+    --exclude="volumes/generated_litecoin_datadir/_data" \
+    --exclude="volumes/generated_elements_datadir/_data" \
+    --exclude="volumes/generated_xmr_data/_data" \
+    --exclude="volumes/generated_dash_datadir/_data" \
     --exclude="volumes/generated_mariadb_datadir" \
     --exclude="volumes/generated_postgres_datadir" \
     --exclude="volumes/generated_electrumx_datadir" \

--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -100,7 +100,10 @@ echo "ℹ️ Archiving files in $(pwd)…"
     --exclude="volumes/generated_litecoin_datadir/_data" \
     --exclude="volumes/generated_elements_datadir/_data" \
     --exclude="volumes/generated_xmr_data/_data" \
-    --exclude="volumes/generated_dash_datadir/_data" \
+    --exclude="volumes/generated_dash_datadir/_data/blocks" \
+    --exclude="volumes/generated_dash_datadir/_data/chainstate" \
+    --exclude="volumes/generated_dash_datadir/_data/indexes" \
+    --exclude="volumes/generated_dash_datadir/_data/debug.log" \
     --exclude="volumes/generated_mariadb_datadir" \
     --exclude="volumes/generated_postgres_datadir" \
     --exclude="volumes/generated_electrumx_datadir" \


### PR DESCRIPTION
Instead of excluding `blocks`, `chainstate` and `indexes` and logs inside the coins `_data` dir we just skip the whole `_data` dir. As we can also remove `_data` when we want to force chain resync I think it should be safe.

This also fixes a bug when you used bitcoin testnet as the exclude pattern would not match anymore on the testnet data dir which is `_data/testnet3/blocks` etc.

I also added Liquid, Monero, Dash which seem to be the only ones popping up on Mattermost and should cover 99% of users. I tested Liquid (elements) and know it works. For Monero and Dash I did not test or double check but assumed the paths from their volumes defined in docker compose fragments. I assumed both also have a `_data` subdirectory.
