### PR TITLE
LND's verrpc should also be exposed via nginx

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -27,7 +27,7 @@
 	{{ range $container := $.Containers }}
 		{{ $serviceName := (index $container.Labels "com.docker.compose.service") }}
 		{{ if (eq $serviceName "lnd_bitcoin") }}
-	location ~* ^/(lnrpc|routerrpc|verrpc)\. {
+	location ~* ^/(lnrpc|routerrpc|verrpc|walletrpc)\. {
 		grpc_read_timeout 6000s;
 		grpc_send_timeout 6000s;
 		grpc_pass grpcs://lnd_bitcoin:10009;

--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -27,7 +27,7 @@
 	{{ range $container := $.Containers }}
 		{{ $serviceName := (index $container.Labels "com.docker.compose.service") }}
 		{{ if (eq $serviceName "lnd_bitcoin") }}
-	location ~* ^/(lnrpc|routerrpc)\. {
+	location ~* ^/(lnrpc|routerrpc|verrpc)\. {
 		grpc_read_timeout 6000s;
 		grpc_send_timeout 6000s;
 		grpc_pass grpcs://lnd_bitcoin:10009;


### PR DESCRIPTION
This is somewhat similar to https://github.com/btcpayserver/btcpayserver-docker/pull/663.
The reason for that change is that without exposing version RPC endpoint LNDmon (https://github.com/lightninglabs/lndmon) is not able to monitor your btcpay lnd node. Actually it doesn't work due to https://github.com/lightninglabs/lndclient/ doing a sanity check at the start trying to get exact version numbers (which means other tools using that library also won't work properly)

The cryptic error message you get from lndmon is:
```
lnd compatibility check failed: version check not implemented, need minimum lnd version of v0.10.0-beta
```

Since one has to authenticate to use this API I don't think this exposes any kind of additional fingerprinting possibilities. Also the attack surface is not increased drastically since verrpc is, well, used to report versions.

Edit: added `walletrpc` too. This one is more tricky since lndmon runs fine for a while, but just crashes later on with
```
lndmon[633702]: WalletCollector ListUnspent failed with: rpc error: code = Unimplemented desc = Not Found: HTTP status code 404; transport: missing content-type field
```