### PR TITLE
Add opt-add-torq

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -159,6 +159,12 @@
   }
   {{ end }}
 
+  {{ if (eq $serviceName "torq") }}
+  location /torq/ {
+    proxy_pass http://torq:8080/;
+  }
+  {{ end }}
+
   {{ if (eq $serviceName "sphinxrelay") }}
   location /sphinxrelay/ {
     proxy_set_header        Host               $host;

--- a/docker-compose-generator/docker-fragments/opt-add-torq.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-torq.yml
@@ -1,0 +1,46 @@
+version: "3.7"
+services:
+  torq:
+    user: "root:root"
+    image: "lncapital/torq:0.10.4-btcpay4"
+    restart: unless-stopped
+    depends_on:
+      - "torq_db"
+    command:
+      - --db.host
+      - torq_db
+      - --db.password
+      - torq_db_password
+      - --lnd.url
+      - lnd_bitcoin:10009
+      - --lnd.macaroon-path
+      - /lnd/admin.macaroon
+      - --lnd.tls-path
+      - /lnd/tls.cert
+      - --torq.cookie-path
+      - /data/.cookie
+      - start
+    volumes:
+      - "lnd_bitcoin_datadir:/lnd:ro"
+      - "lnd_bitcoin_torq_datadir:/data"
+    links:
+      - lnd_bitcoin
+  torq_db:
+    image: "timescale/timescaledb:latest-pg14"
+    environment:
+      POSTGRES_PASSWORD: torq_db_password
+    volumes:
+      - torq_datadir:/var/lib/postgresql/data
+
+  btcpayserver:
+    environment:
+      BTCPAY_BTCEXTERNALTORQ: "server=/torq/cookie-login;cookiefile=/etc/lnd_bitcoin_torq/.cookie"
+    volumes:
+      - "lnd_bitcoin_torq_datadir:/etc/lnd_bitcoin_torq"
+
+volumes:
+  torq_datadir:
+  lnd_bitcoin_torq_datadir:
+required:
+  - "bitcoin-lnd"
+  - "opt-lnd-grpc"


### PR DESCRIPTION
Companion PR to https://github.com/btcpayserver/btcpayserver/pull/4296 to enable Torq

This was tested on our node.

It will not work until the BTCPayServer PR is merged and this repo is updated with the latest BTCPayServer tag.