### PR TITLE
Activate mempoolfullrbf on BTCPay deployments

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin.yml
@@ -42,3 +42,5 @@ volumes:
 
 exclusive:
   - bitcoin-node
+recommended:
+  - "opt-mempoolfullrbf"

--- a/docker-compose-generator/docker-fragments/opt-mempoolfullrbf.yml
+++ b/docker-compose-generator/docker-fragments/opt-mempoolfullrbf.yml
@@ -1,0 +1,8 @@
+version: "3"
+#  must not use opt-save-storage
+
+services:
+  bitcoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        mempoolfullrbf=1


### PR DESCRIPTION
# Explanation

Mempool Full RBF is a mempool policy.
If this policy is turned on, when a new transaction is considered to be added to mempool and a conflict (double spending) is detected:
* If the new transaction has higher fee, then the previous transaction get replaced (in any case)
* Else the the new transaction is ignored

Without this policy,
* If the new transaction has higher fee AND the previous transaction signal RBF, then the previous transaction get replaced.
* Else the the new transaction is ignored

Bitcoin Core 24.0 allows nodes to activate this policy, however, it is turned off by default.

# Rational

We should activate `mempoolfullrbf=1`, because as a merchant you want to know if a payment is getting double spent as soon as possible.

Without `mempoolfullrbf=1` if a customer is double spending a payment with a transaction not signaling RBF, the merchant would only know after confirmation.

However, some users doesn't want to activate this policy, as some people consider that while it aligns with the incentive of the merchant to activate it, it is considered against the interests of the network, as it make accepting a payment with 0 confirmations harder once the policy is widely deployed.

For this reason, people who wants to disable this policy may opt out with

```bash
BTCPAYGEN_EXCLUDE_FRAGMENTS="$BTCPAYGEN_EXCLUDE_FRAGMENTS;opt-mempoolfullrbf"
. btcpay-setup.sh -i
```