### PR TITLE
Allow NBX to provide rpc proxy

### DIFF
--- a/docker-compose-generator/docker-fragments/nbxplorer.yml
+++ b/docker-compose-generator/docker-fragments/nbxplorer.yml
@@ -15,6 +15,7 @@ services:
       NBXPLORER_POSTGRES: User ID=postgres;Host=postgres;Port=5432;Application Name=nbxplorer;MaxPoolSize=20;Database=nbxplorer${NBITCOIN_NETWORK:-regtest}
       NBXPLORER_AUTOMIGRATE: 1
       NBXPLORER_NOMIGRATEEVTS: 1
+      NBXPLORER_EXPOSERPC: 1
     links:
       - postgres
     volumes:


### PR DESCRIPTION
This allows btcpay to use the node rpc directly instead of needing direct rpc access. Should not be any security implications since nbx is still an internal service.