### PR TITLE
docs: rpcmiddleware setting for Lightning Terminal (LiT)

### DIFF
--- a/docs/lightning-terminal.md
+++ b/docs/lightning-terminal.md
@@ -26,3 +26,21 @@ To see the logs of the Lightning Terminal service, you can run this command:
 ```bash
 docker logs -f generated_lnd_lit_1
 ```
+
+To enable the RPC Middleware Interceptor in the LND settings (lnd.conf), create a custom fragment in `docker-compose-generator/docker-fragments/opt-lnd-config.custom.yml` like this:
+
+```yml
+version: "3"
+services:
+  lnd_bitcoin:
+    environment:
+      LND_EXTRA_ARGS: |
+        rpcmiddleware.enable=true
+```
+
+Afterwards the configuration has to be added to the additional fragments and setup needs to be run:
+
+```bash
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-lnd-config.custom"
+. ./btcpay-setup.sh -i
+```


### PR DESCRIPTION
After adding the fragment `opt-add-lightning-terminal` to enable the Lightning Terminal (LiT), I encountered an error message that reads as follows:

```
2023-04-09 11:29:18.975 [INF] LITD: Starting LiT macaroon service
2023-04-09 11:29:19.051 [INF] AUTO: Starting Autopilot Client
2023-04-09 11:29:19.825 [INF] LITD: Starting LiT session server
2023-04-09 11:29:19.825 [INF] LITD: Starting LiT account service
2023-04-09 11:29:19.838 [INF] LITD: Starting LiT middleware manager
2023-04-09 11:29:19.839 [ERR] LNDC: Could not receive from interceptor stream: rpc error: code = Unknown desc = RPC middleware not enabled in config
2023-04-09 11:29:19.840 [ERR] LITD: Could not start subservers: context canceled
```

The error occurred because the RPC Middleware Interceptor in LND was not enabled, which is required for the Lightning Terminal to function properly. To resolve this issue, a custom fragment needs to be created.

Alternatively, you may also consider setting a new environment variable that could simplify the process.