### PR TITLE
Lightning Terminal (LiT): enable rpcmiddleware in lnd.conf

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-lightning-terminal.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-lightning-terminal.yml
@@ -3,6 +3,10 @@ services:
   btcpayserver:
     environment:
       BTCPAY_EXTERNALSERVICES: "Lightning Terminal:${BTCPAY_PROTOCOL:-https}://${BTCPAY_HOST}/lit/;"
+  lnd_bitcoin:
+    environment:
+      LND_EXTRA_ARGS: |
+        rpcmiddleware.enable=true
   lnd_lit:
     image: "lightninglabs/lightning-terminal:v0.8.6-alpha-path-prefix"
     restart: unless-stopped


### PR DESCRIPTION
After adding the fragment `opt-add-lightning-terminal` to enable the Lightning Terminal (LiT), I encountered an error message that reads as follows:

```
2023-04-09 11:29:18.975 [INF] LITD: Starting LiT macaroon service
2023-04-09 11:29:19.051 [INF] AUTO: Starting Autopilot Client
2023-04-09 11:29:19.825 [INF] LITD: Starting LiT session server
2023-04-09 11:29:19.825 [INF] LITD: Starting LiT account service
2023-04-09 11:29:19.838 [INF] LITD: Starting LiT middleware manager
2023-04-09 11:29:19.839 [ERR] LNDC: Could not receive from interceptor stream: rpc error: code = Unknown desc = RPC middleware not enabled in config
2023-04-09 11:29:19.840 [ERR] LITD: Could not start subservers: context canceled
```

The error occurred because the RPC Middleware Interceptor in LND was not enabled, which is required for the Lightning Terminal to function properly. 

With this change the LiT fragment extend the LND config with `rpcmiddleware.enable=true`.

Thanks to @dennisreimann for the feedback.

Closes #767. 