### PR TITLE
Thunderhub: Do not pin the hash

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-thunderhub.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-thunderhub.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - "lnd_bitcoin_thub_datadir:/etc/lnd_bitcoin_thub_datadir"
   bitcoin_thub:
-    image: apotdevin/thunderhub:base-v0.13.18@sha256:7f9208ced43be324331c6290d58813ba66fb359097290069b617d5f35ac6e741
+    image: apotdevin/thunderhub:base-v0.13.18
     restart: unless-stopped
     stop_signal: SIGKILL
     environment:


### PR DESCRIPTION
This hash forces the installation of the linux/amd64 version. Fixes #769.