### PR TITLE
LND: Auto-compact database on startup

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -31,6 +31,7 @@ services:
         tlsextradomain=lnd_bitcoin
         no-rest-tls=1
         protocol.wumbo-channels=1
+        db.bolt.auto-compact=true
     ports:
       - "9735:9735"
     expose:


### PR DESCRIPTION
Saves server resources and closes #780.

## How to test this fragment

While this isn't released you can test it by [editing your lnd.conf](https://docs.btcpayserver.org/FAQ/LightningNetwork/#how-to-edit-lndconf). The custom fragment would need to contain this:

```yml
version: '3'
services:
  lnd_bitcoin:
    environment:
      LND_EXTRA_ARGS: |
        db.bolt.auto-compact=true
```

Afterwards you need to apply the config and restart the docker-compose services:

```bash
. ./btcpay-setup -i
```

## Test run

I tested this on a fairly large instance with no compaction run before, which amounts to a channel.db of 22 GB in size:

```bash
# ls -lAh /var/lib/docker/volumes/generated_lnd_bitcoin_datadir/_data/data/graph/mainnet/
-rw------- 1 root root  22G May  3 15:58 channel.db
```

The LND log (`docker logs -f btcpayserver_lnd_bitcoin`) when restarting:

```
[initunlocklnd] LND still didn't start, got 000 status code back... waiting another 2 seconds...
2023-05-03 13:59:13.549 [INF] LTND: Version: 0.16.2-beta commit=basedon-v0.16.2-beta-fresh-btcpay, build=production, logging=default, debuglevel=info
2023-05-03 13:59:13.549 [INF] LTND: Active chain: Bitcoin (network=mainnet)
2023-05-03 13:59:13.556 [INF] RPCS: RPC server listening on 127.0.0.1:10008
2023-05-03 13:59:13.557 [INF] RPCS: RPC server listening on 172.19.0.9:10009
2023-05-03 13:59:13.556 [INF] RPCS: RPC server listening on 127.0.0.1:10009
2023-05-03 13:59:13.572 [INF] RPCS: gRPC proxy started at 172.19.0.9:8080
2023-05-03 13:59:13.572 [INF] LTND: Opening the main database, this might take a few minutes...
2023-05-03 13:59:13.572 [INF] LTND: Opening bbolt database, sync_freelist=false, auto_compact=true
2023-05-03 13:59:13.572 [INF] CHDB: Compacting database file at /root/.lnd/data/graph/mainnet/channel.db
2023-05-03 13:59:15.117 [ERR] RPCS: [/lnrpc.Lightning/ExportAllChannelBackups]: waiting to start, RPC services not available
2023-05-03 13:59:15.168 [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: waiting to start, RPC services not available
[initunlocklnd] Still waiting on LND, got response for wallet status: {"state":"WAITING_TO_START"} ... waiting another 2 seconds...

...

2023-05-03 14:52:50.603 [INF] CHDB: DB compaction of /root/.lnd/data/graph/mainnet/channel.db successful, 3714711552 -> 1833320448 bytes (gain=2.03x)
2023-05-03 14:52:50.610 [INF] CHDB: Swapping old DB file from /root/.lnd/data/graph/mainnet/temp-dont-use.db to /root/.lnd/data/graph/mainnet/channel.db
2023-05-03 14:52:51.194 [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: waiting to start, RPC services not available
[initunlocklnd] Still waiting on LND, got response for wallet status: {"state":"WAITING_TO_START"} ... waiting another 2 seconds...
2023-05-03 14:52:51.666 [INF] LTND: Creating local graph and channel state DB instances
2023-05-03 14:52:53.230 [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: waiting to start, RPC services not available
[initunlocklnd] Still waiting on LND, got response for wallet status: {"state":"WAITING_TO_START"} ... waiting another 2 seconds...
2023-05-03 14:52:55.260 [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: waiting to start, RPC services not available
[initunlocklnd] Still waiting on LND, got response for wallet status: {"state":"WAITING_TO_START"} ... waiting another 2 seconds...
2023-05-03 14:52:57.287 [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: waiting to start, RPC services not available
[initunlocklnd] Still waiting on LND, got response for wallet status: {"state":"WAITING_TO_START"} ... waiting another 2 seconds...
2023-05-03 14:52:58.278 [INF] CHDB: Checking for schema update: latest_version=29, db_version=29
2023-05-03 14:52:58.278 [INF] CHDB: Checking for optional update: prune_revocation_log=false, db_version=empty
2023-05-03 14:52:58.278 [INF] LTND: Database(s) now open (time_to_open=53m44.706178588s)!
2023-05-03 14:52:58.283 [INF] LTND: We're not running within systemd or the service type is not 'notify'
2023-05-03 14:52:58.283 [INF] LTND: Waiting for wallet encryption password. Use `lncli create` to create a wallet, `lncli unlock` to unlock an existing wallet, or `lncli changepassword` to change the password of an existing wallet and unlock it.
2023-05-03 14:52:59.313 [ERR] RPCS: [/lnrpc.Lightning/GetInfo]: wallet locked, unlock it to enable full RPC access
[initunlocklnd] Wallet and Unlock files are present... parsing wallet password and unlocking lnd
2023-05-03 14:53:03.172 [INF] LNWL: Opened wallet
```

For the channel.db with initially 22 GB it took almost an hour to compact. That process reduced the size to 14 GB:

```bash
# ls -lAh /var/lib/docker/volumes/generated_lnd_bitcoin_datadir/_data/data/graph/mainnet/
-rw-r--r-- 1 root root  14G May  3 16:54 channel.db
-rw------- 1 root root    8 May  3 16:45 channel.db.last-compacted
```

As we do not touch the default interval for compaction, this would run again with the next restart after 7 days (default: 168 hours).