### PR TITLE
add BACKUP_TIMESTAMP to btcpay-backup.sh

### DIFF
--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -34,6 +34,12 @@ backup_dir="$docker_dir/volumes/backup_datadir/_data"
 postgres_dump_path="$docker_dir/$postgres_dump_name"
 backup_path="$backup_dir/backup.tar.gz"
 
+# Backup with custom file name and timestamp:
+if [ "$BACKUP_TIMESTAMP" == true ]; then
+  timestamp=$(date "+%Y%m%d-%H%M%S")
+  backup_path="$backup_dir/$timestamp-backup.tar.gz"
+fi
+
 # ensure backup dir exists
 if [ ! -d "$backup_dir" ]; then
   mkdir -p $backup_dir


### PR DESCRIPTION
I migrated the BACKUP_TIMESTAMP functionality to save the backup with datetime as part of the file name from the old backup.sh.

If my change is accepted, I plan to update the documentation to include information on the newly added environment variable.