### PR TITLE
Updating LND container to support signet

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   lnd_bitcoin:
-    image: btcpayserver/lnd:v0.16.2-beta
+    image: btcpayserver/lnd:v0.16.2-beta-1
     container_name: btcpayserver_lnd_bitcoin
     restart: unless-stopped
     environment:


### PR DESCRIPTION
This was requested by `zoop` in our Mattermost:
https://chat.btcpayserver.org/btcpayserver/pl/fhfgu6x9x3nkjkqif5gbcczjiy

No rush to merge PR, and update LND images across BTCPay Servers, we can do this as part of next major release.

Opening PR mostly for reference for those tha tneed `signet`.