### PR TITLE
Update lightning-terminal.md

### DIFF
--- a/docs/lightning-terminal.md
+++ b/docs/lightning-terminal.md
@@ -13,7 +13,7 @@ To install the Lightning Terminal service, you need to set a password for the lo
 export LIT_PASSWD="sUpErSeCuRe"
 
 # Add fragment and run setup
-BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-add-lightning-terminal"
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-add-lightning-terminal"
 . btcpay-setup.sh -i
 ```
 


### PR DESCRIPTION
Adding a missing 'export' command to the installation docs for Lightning Terminal (Lit)

This also adds consistency with other [doc pages](https://docs.btcpayserver.org/Docker/#generated-docker-compose) that show the `export` command for the same env variable.