### PR TITLE
exclude blocks and chainstate from doge backup

### DIFF
--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -100,6 +100,8 @@ echo "ℹ️ Archiving files in $(pwd)…"
     --exclude="volumes/generated_litecoin_datadir/_data" \
     --exclude="volumes/generated_elements_datadir/_data" \
     --exclude="volumes/generated_xmr_data/_data" \
+    --exclude="volumes/generated_dogecoin_datadir/_data/blocks" \
+    --exclude="volumes/generated_dogecoin_datadir/_data/chainstate" \
     --exclude="volumes/generated_dash_datadir/_data/blocks" \
     --exclude="volumes/generated_dash_datadir/_data/chainstate" \
     --exclude="volumes/generated_dash_datadir/_data/indexes" \


### PR DESCRIPTION
A user on TG had a problem with creating a backup of his Altcoin build instance from Lunanode because the backup exceeded the available storage on / partition.

I hope that the missing exclude for dogecoin was the reason, all other alts he uses seem to be in our exclude list.

Would appreciate if this could be merged in a timely manner.
Thanks.

cc @dennisreimann 