### PR TITLE
Fix Monero image tag

### DIFF
--- a/docker-compose-generator/docker-fragments/monero.yml
+++ b/docker-compose-generator/docker-fragments/monero.yml
@@ -4,7 +4,7 @@ services:
   monerod:
     restart: unless-stopped
     container_name: btcpayserver_monerod
-    image: btcpayserver/monero:0.18.2.2-4
+    image: btcpayserver/monero:0.18.2.2
     entrypoint: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
     expose:
       - "18081"
@@ -14,7 +14,7 @@ services:
   monerod_wallet:
     restart: unless-stopped
     container_name: btcpayserver_monero_wallet
-    image: btcpayserver/monero:0.18.2.2-4
+    image: btcpayserver/monero:0.18.2.2
     entrypoint: monero-wallet-rpc --rpc-bind-ip=0.0.0.0 --disable-rpc-login --confirm-external-bind --rpc-bind-port=18082 --non-interactive --trusted-daemon  --daemon-address=monerod:18081 --wallet-file=/wallet/wallet --password-file=/wallet/password --tx-notify="/bin/sh ./scripts/notifier.sh  -X GET http://btcpayserver:49392/monerolikedaemoncallback/tx?cryptoCode=xmr&hash=%s"
     expose:
       - "18082"


### PR DESCRIPTION
It seems that https://github.com/btcpayserver/dockerfile-deps/commit/1d7b2a41909f59da5bcc14237d59bcda1ff64f56 fixed Monero, but the tag was improperly referenced here as `-4` when the folder is simply `0.18.2.2` in `dockerfile-deps`:

https://github.com/btcpayserver/dockerfile-deps/tree/master/Monero/0.18.2.2

I tested the Monero container on it's own from https://github.com/btcpayserver/dockerfile-deps/commit/1d7b2a41909f59da5bcc14237d59bcda1ff64f56 and it seems to use the proper user and group and work to the best of my abilities to test.