### PR TITLE
Revert "Allow CORS for LND REST API"

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -31,7 +31,6 @@ services:
         tlsextradomain=lnd_bitcoin
         no-rest-tls=1
         protocol.wumbo-channels=1
-        restcors=*
     ports:
       - "9735:9735"
     expose:


### PR DESCRIPTION
This reverts commit 6dc2c783b193e96c8ce6345977c98fd6a080b5ae.

Original issue:
https://github.com/getAlby/lightning-browser-extension/issues/2522

With https://github.com/getAlby/lightning-browser-extension/pull/2567 CORS should no longer be an issue. 