### PR TITLE
Update load-utxo-set.sh

### DIFF
--- a/contrib/FastSync/load-utxo-set.sh
+++ b/contrib/FastSync/load-utxo-set.sh
@@ -32,7 +32,7 @@ if ! [[ "$BTCPAYGEN_ADDITIONAL_FRAGMENTS" == *"opt-save-storage"* ]]; then
   echo "Pruning must be enabled, please update BTCPAYGEN_ADDITIONAL_FRAGMENTS by running:"
   echo ""
   echo 'BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-save-storage-s"'
-  echo '. btcpay-setup -i'
+  echo '. btcpay-setup.sh -i'
   exit 1
 fi
 


### PR DESCRIPTION
adding extension to exec call, gave me an error on Ubuntu 22.10
```shell

root@btcpayserver:~/btcpayserver-docker# cd $BTCPAY_BASE_DIRECTORY/btcpayserver-docker/contrib/FastSync
./load-utxo-set.sh
Pruning must be enabled, please update BTCPAYGEN_ADDITIONAL_FRAGMENTS by running:

BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-save-storage-s"
. btcpay-setup -i
root@btcpayserver:~/btcpayserver-docker/contrib/FastSync# BTCPAYGEN_ADDITIONAL_FRAGMENTS="$BTCPAYGEN_ADDITIONAL_FRAGMENTS;opt-save-storage-s"
. btcpay-setup -i
-bash: btcpay-setup: No such file or directory
root@btcpayserver:~/btcpayserver-docker/contrib/FastSync# cd ..\
> 
root@btcpayserver:~/btcpayserver-docker/contrib# cd ..\
> 
root@btcpayserver:~/btcpayserver-docker# . btcpay-setup -i
-bash: btcpay-setup: No such file or directory
root@btcpayserver:~/btcpayserver-docker# ./btcpay-setup.sh -i
This script must be sourced ". btcpay-setup.sh"
``` 
¯\\_(ツ)_/¯