### PR TITLE
Add Fulcrum

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-fulcrum.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-fulcrum.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services:
+  bitcoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        rpcauth=electrumx:7d8ee47c089e6072635f82b34796e878$$13649d99453ccdf78e85007286422599c00e6953289f41bf8e92961076ba14db
+  fulcrum:
+    image: cculianu/fulcrum:v1.9.3
+    restart: unless-stopped
+    expose:
+      - "50001"
+    ports:
+      - "50002:50002"
+    volumes:
+      - "fulcrum_datadir:/data"
+    command: "Fulcrum -b bitcoind:43782 -t 0.0.0.0:50001 -s 0.0.0.0:50002 -u electrumx -p 1VmSUVGBuLNWvZl0LExRDW0tvl6196-47RfXIzS384g="
+volumes:
+  fulcrum_datadir:
+incompatible:
+  - pruning
+required:
+  - "opt-txindex"

--- a/docker-compose-generator/docker-fragments/opt-add-mempool-fulcrum.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-mempool-fulcrum.yml
@@ -1,0 +1,70 @@
+version: '3'
+
+# reference: https://github.com/mempool/mempool/blob/master/docker/docker-compose.yml
+services:
+  bitcoind:
+    environment:
+      BITCOIN_EXTRA_ARGS: |
+        # We need to use rpcauth because we also need cookieauth. rpcpassword disabled cookie file auth.
+        # Be careful if you copy the line below from the docker-compose.yml! A dollar sign is escaped.
+        rpcauth=mempool:d77ee0acf132038f6aaa9d4500d745ec$$72cc78dcf18191c91d10c15ff8f7c3dbbd170c4d3107cca35d71c6bf96af2ed9
+  mempool_web:
+    image: mempool/frontend:v2.5.0
+    restart: on-failure
+    stop_grace_period: 1m
+    command: "./wait-for mempool_db:3306 --timeout=720 -- nginx -g 'daemon off;'"
+    expose:
+      - "8080"
+    environment:
+      FRONTEND_HTTP_PORT: "8080"
+      BACKEND_MAINNET_HTTP_HOST: "mempool_api"
+
+  mempool_api:
+    image: mempool/backend:v2.5.0
+    restart: on-failure
+    stop_grace_period: 1m
+    command: "./wait-for-it.sh mempool_db:3306 --timeout=720 --strict -- ./start.sh"
+    expose:
+      - "8999"
+    environment:
+      MEMPOOL_BACKEND: "electrum"
+      MEMPOOL_CACHE_DIR: "/backend/cache"
+      ELECTRUM_HOST: "fulcrum"
+      ELECTRUM_PORT: "50001"
+      ELECTRUM_TLS_ENABLED: "false"
+      CORE_RPC_HOST: "bitcoind"
+      CORE_RPC_PORT: "43782"
+      CORE_RPC_USERNAME: "mempool"
+      CORE_RPC_PASSWORD: "mempool"
+      DATABASE_ENABLED: "true"
+      DATABASE_HOST: "mempool_db"
+      DATABASE_DATABASE: "mempool"
+      DATABASE_USERNAME: "mempool"
+      DATABASE_PASSWORD: "mempool"
+      REDIS_ENABLED: "false"
+
+  mempool_db:
+    image: mariadb:10.11
+    restart: on-failure
+    expose:
+      - "3306"
+    volumes:
+      - "mempool_db_datadir:/var/lib/mysql"
+    environment:
+      MYSQL_DATABASE: "mempool"
+      MYSQL_USER: "mempool"
+      MYSQL_PASSWORD: "mempool"
+      MYSQL_ROOT_PASSWORD: "admin"
+
+  btcpayserver:
+    environment:
+      BTCPAY_EXTERNALSERVICES: "Mempool Explorer:/mempool"
+
+volumes:
+  mempool_db_datadir:
+
+required:
+  - "opt-add-fulcrum"
+
+incompatible:
+  - pruning


### PR DESCRIPTION
I would like to add the [Fulcrum](https://github.com/cculianu/Fulcrum) explorer as an option/alternative to electrumX.

However I don't know how to make this run with the existing mempool.space config. Hence I created a customized copy of the same to work with Fulcrum.

The current config is running on one of my lab nodes with pretty impressive performance.

I'm putting this here as Draft in the hope that someone has an idea how to fix my issue.

I think we also still need to add the docker image creation steps to the build all images script. And update the Readme accordingly.