### PR TITLE
Bumping LND to 0.17.2-beta

### DIFF
--- a/contrib/build-all-images.sh
+++ b/contrib/build-all-images.sh
@@ -144,12 +144,12 @@ DOCKERFILE="linuxamd64.Dockerfile"
 [[ "$(uname -m)" == "armv7l" ]] && DOCKERFILE="linuxarm32v7.Dockerfile"
 # https://raw.githubusercontent.com/btcpayserver/lnd/basedon-v0.16.4-beta-1/linuxarm64v8.Dockerfile
 [[ "$(uname -m)" == "aarch64" ]] && DOCKERFILE="linuxarm64v8.Dockerfile"
-echo "Building btcpayserver/lnd:v0.17.1-beta"
+echo "Building btcpayserver/lnd:v0.17.2-beta"
 git clone https://github.com/btcpayserver/lnd lnd
 cd lnd
 git checkout basedon-v0.16.4-beta-1
 cd "$(dirname $DOCKERFILE)"
-docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.1-beta" .
+docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.2-beta" .
 cd - && cd ..
 
 

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   lnd_bitcoin:
-    image: btcpayserver/lnd:v0.17.1-beta
+    image: btcpayserver/lnd:v0.17.2-beta
     container_name: btcpayserver_lnd_bitcoin
     restart: unless-stopped
     environment:


### PR DESCRIPTION
I'm urgently releasing bump to LND 0.17.2-beta as there is unexpected termination case during startup for some nodes:  https://github.com/lightningnetwork/lnd/issues/8184

Fix for this is the only change since 0.17.1-beta, and since @roasbeef pushed new version 25 minutes ago, I thought we get ahead of potential problems, so am opening this PR.

Will test it on my server and merge if there are no problems.