### PR TITLE
Update docker version during btcpay-update

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -144,6 +144,30 @@ docker_update() {
             apt install libseccomp2 -t buster-backports
         fi
     fi
+
+    # Can't run with docker-ce before 20.10.10... check against version 21 instead, easier to compare
+    if [ "21" \> "$(docker version -f "{{ .Server.Version }}")" ]; then
+        echo "Updating docker, old version can't run some images (https://docs.linuxserver.io/FAQ/#jammy)"
+        echo \
+        "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        "$(lsb_release -cs)" stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+        apt-get update
+        apt-get upgrade -y  docker-ce docker-ce-cli containerd.io
+
+        # Possible that old distro like xenial doesn't have it anymore, if so, just take
+        # the next distrib
+        if [ "21" \> "$(docker version -f "{{ .Server.Version }}")" ]; then
+            echo "Updating docker, with bionic's version"
+            echo \
+            "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+            bionic stable" | \
+            tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update
+            apt-get upgrade -y  docker-ce docker-ce-cli containerd.io
+        fi
+    fi
 }
 
 btcpay_up() {


### PR DESCRIPTION
Without bumping docker version to more than 20.10.10, then we end up with an error `Failed to create CoreCLR, HRESULT: 0x80070008` on docker images built for .NET 8.0.

[This FAQ](https://docs.linuxserver.io/FAQ/#jammy) suggest two workarounds:
1. Update docker
2. Run docker with `--security-opt seccomp=unconfined`

This implement the first. I try to update docker using `apt-get` with the distro's repository.
If that fails, I try to use `bionic` instead, which is the distro above. (For example, Xenial last docker version is `20.10.7`, so it needs this workaround.)