### PR TITLE
Bumping LND to 0.17.3-beta

### DIFF
--- a/contrib/build-all-images.sh
+++ b/contrib/build-all-images.sh
@@ -144,12 +144,12 @@ DOCKERFILE="linuxamd64.Dockerfile"
 [[ "$(uname -m)" == "armv7l" ]] && DOCKERFILE="linuxarm32v7.Dockerfile"
 # https://raw.githubusercontent.com/btcpayserver/lnd/basedon-v0.17.2-beta/linuxarm64v8.Dockerfile
 [[ "$(uname -m)" == "aarch64" ]] && DOCKERFILE="linuxarm64v8.Dockerfile"
-echo "Building btcpayserver/lnd:v0.17.2-beta"
+echo "Building btcpayserver/lnd:v0.17.3-beta"
 git clone https://github.com/btcpayserver/lnd lnd
 cd lnd
 git checkout basedon-v0.17.2-beta
 cd "$(dirname $DOCKERFILE)"
-docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.2-beta" .
+docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.3-beta" .
 cd - && cd ..
 
 

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   lnd_bitcoin:
-    image: btcpayserver/lnd:v0.17.2-beta
+    image: btcpayserver/lnd:v0.17.3-beta
     container_name: btcpayserver_lnd_bitcoin
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Creating this PR to prepare for updating of LND in our docker deployment.
Leaving it in draft mode so it's tested and merged as part of publishing new version.

https://github.com/btcpayserver/btcpayserver/pull/5614

To test on your server connect with SSH and do:

```
git fetch
git checkout feat/lnd-v0.17.3-beta
btcpay-update.sh
```