### PR TITLE
Fix potential real_ip_header is duplicate error

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -39,9 +39,11 @@
 		{{ end }}
 		{{ if $container.Env.REAL_IP_HEADER }}
 		{{ range $containerNetwork := $container.Networks }}
-		set_real_ip_from {{ $containerNetwork.IP }};
+        set_real_ip_from {{ $containerNetwork.IP }};
 		{{ end }}
+		{{ if (ne $container.Env.REAL_IP_HEADER "X-Real-IP") }}
         real_ip_header {{ $container.Env.REAL_IP_HEADER }};
+		{{ end }}
 		{{ end }}
 		{{ if (eq $serviceName "bitcoin_rtl") }}
 	location /rtl/ {


### PR DESCRIPTION
Fix https://github.com/btcpayserver/btcpayserver-docker/issues/852

While I didn't found the root cause of the issue, [real_ip_header](https://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header) is already set to `X-Real-Ip` by default, as such we shouldn't set it explicitly, this will fix the issue as there is no dups anymore.