### PR TITLE
Update docker-compose

### DIFF
--- a/btcpay-setup.sh
+++ b/btcpay-setup.sh
@@ -428,17 +428,6 @@ if ! [[ -x "$(command -v docker)" ]] || ! [[ -x "$(command -v docker-compose)" ]
     fi
 
     docker_update
-
-    if ! [[ -x "$(command -v docker-compose)" ]]; then
-        if ! [[ "$OSTYPE" == "darwin"* ]] && $HAS_DOCKER; then
-            echo "Trying to install docker-compose by using the btcpayserver/docker-compose ($(uname -m))"
-            ! [[ -d "dist" ]] && mkdir dist
-            docker run --rm -v "$(pwd)/dist:/dist" btcpayserver/docker-compose:1.28.6
-            mv dist/docker-compose /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
-            rm -rf "dist"
-        fi
-    fi
 fi
 
 if $HAS_DOCKER; then

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -47,6 +47,7 @@ services:
 
   bitcoin_rtl:
     image: shahanafarooqui/rtl:0.14.1
+    container_name: generated_lnd_bitcoin_rtl_1
     restart: unless-stopped
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1

--- a/docker-compose-generator/docker-fragments/btcpayserver.yml
+++ b/docker-compose-generator/docker-fragments/btcpayserver.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   btcpayserver:
     restart: unless-stopped
+    container_name: generated_btcpayserver_1
     image: ${BTCPAY_IMAGE:-btcpayserver/btcpayserver:1.12.3$<BTCPAY_BUILD_CONFIGURATION>?}
     expose:
       - "49392"

--- a/docker-compose-generator/docker-fragments/nbxplorer.yml
+++ b/docker-compose-generator/docker-fragments/nbxplorer.yml
@@ -4,6 +4,7 @@ services:
 
   nbxplorer:
     restart: unless-stopped
+    container_name: generated_nbxplorer_1
     image: nicolasdorier/nbxplorer:2.4.4
     expose:
       - "32838"

--- a/docker-compose-generator/docker-fragments/opt-add-fireflyiii.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-fireflyiii.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   fireflyiii:
     image: fireflyiii/core:latest
+    container_name: generated_fireflyiii_1
     environment:
       - APP_ENV=local
       - APP_KEY=MustBe32DropDbAndChangeItIfUWant

--- a/docker-compose-generator/docker-fragments/opt-add-tallycoin-connect.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-tallycoin-connect.yml
@@ -7,6 +7,7 @@ services:
       - "tallycoin_connect_datadir:/etc/tallycoin_connect_datadir"
   tallycoin_connect:
     image: "djbooth007/tallycoin_connect:v1.8.0"
+    container_name: generated_tallycoin_connect_1
     restart: unless-stopped
     expose:
       - "8123"

--- a/docker-compose-generator/docker-fragments/opt-add-thunderhub.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-thunderhub.yml
@@ -7,6 +7,7 @@ services:
       - "lnd_bitcoin_thub_datadir:/etc/lnd_bitcoin_thub_datadir"
   bitcoin_thub:
     image: apotdevin/thunderhub:base-v0.13.29@sha256:ed00149728a77469d39d4e9a9ff699c49a090063db201b4457edaf06211a99e8
+    container_name: generated_bitcoin_thub_1
     restart: unless-stopped
     stop_signal: SIGKILL
     environment:

--- a/docker-compose-generator/docker-fragments/opt-add-woocommerce.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-woocommerce.yml
@@ -21,6 +21,7 @@ services:
 
   mariadb:
     image: mariadb:10.4
+    container_name : generated_mariadb_1
     environment:
       MYSQL_ROOT_PASSWORD: wordpressdb
       MYSQL_DATABASE: wordpress

--- a/docker-compose-generator/docker-fragments/postgres.yml
+++ b/docker-compose-generator/docker-fragments/postgres.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   postgres:
     restart: unless-stopped
+    container_name: generated_postgres_1
     image: btcpayserver/postgres:13.13
     command: [ "-c", "random_page_cost=1.0", "-c", "shared_preload_libraries=pg_stat_statements" ]
     environment:


### PR DESCRIPTION
The current version of docker-compose we ship with is Mar 23, 2021, this is an attempt to update without breaking changes.

Note that docker version 2 has breaking change on the default name of container. In order to not break our scripts and our docs, I needed to set explicitely the container_name to the same as the old version of docker-compose compose.

Old installs never had docker-compose even updated, making them using version that are now out of support.