### PR TITLE
Increase shm_size for postgres container

### DIFF
--- a/docker-compose-generator/docker-fragments/postgres.yml
+++ b/docker-compose-generator/docker-fragments/postgres.yml
@@ -4,6 +4,7 @@ services:
   postgres:
     restart: unless-stopped
     container_name: generated_postgres_1
+    shm_size: 256mb
     image: btcpayserver/postgres:13.13
     command: [ "-c", "random_page_cost=1.0", "-c", "shared_preload_libraries=pg_stat_statements" ]
     environment:


### PR DESCRIPTION
This prevent VACUUM from failing with error

```
ERROR: "could not resize shared memory segment "/PostgreSQL.1038930517" to 67128416 bytes: No space left on device"
```

This degrades the performances of the database