### PR TITLE
Bumping LND to 0.17.4-beta-rc1

### DIFF
--- a/Tools/lnd/lnd_recreate_volume.sh
+++ b/Tools/lnd/lnd_recreate_volume.sh
@@ -25,6 +25,7 @@ docker volume rm --force generated_lnd_bitcoin_datadir
 # https://github.com/btcpayserver/btcpayserver-docker/issues/272
 docker volume rm --force production_lnd_bitcoin_datadir
 
-btcpay-up.sh
+# doing this so if there are new env variables in lnd-bitcoin.yml they are taken into account (LND_SKIP_INITUNLOCK)
+. btcpay-setup.sh -i
 
 echo "LND container recreated"

--- a/bitcoin-lncli.ps1
+++ b/bitcoin-lncli.ps1
@@ -1,1 +1,1 @@
-docker exec btcpayserver_lnd_bitcoin lncli --macaroonpath /root/.lnd/admin.macaroon $args
+docker exec -it btcpayserver_lnd_bitcoin lncli --macaroonpath /root/.lnd/admin.macaroon $args

--- a/bitcoin-lncli.sh
+++ b/bitcoin-lncli.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker exec btcpayserver_lnd_bitcoin lncli --macaroonpath /root/.lnd/admin.macaroon "$@"
+docker exec -it btcpayserver_lnd_bitcoin lncli --macaroonpath /root/.lnd/admin.macaroon "$@"

--- a/contrib/build-all-images.sh
+++ b/contrib/build-all-images.sh
@@ -128,12 +128,12 @@ DOCKERFILE="linuxamd64.Dockerfile"
 [[ "$(uname -m)" == "armv7l" ]] && DOCKERFILE="linuxarm32v7.Dockerfile"
 # https://raw.githubusercontent.com/btcpayserver/lnd/basedon-v0.17.3-beta/linuxarm64v8.Dockerfile
 [[ "$(uname -m)" == "aarch64" ]] && DOCKERFILE="linuxarm64v8.Dockerfile"
-echo "Building btcpayserver/lnd:v0.17.3-beta"
+echo "Building btcpayserver/lnd:v0.17.4-beta-rc1"
 git clone https://github.com/btcpayserver/lnd lnd
 cd lnd
 git checkout basedon-v0.17.3-beta
 cd "$(dirname $DOCKERFILE)"
-docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.3-beta" .
+docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.4-beta-rc1" .
 cd - && cd ..
 
 

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   lnd_bitcoin:
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta-rc1
     container_name: btcpayserver_lnd_bitcoin
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Creating this PR to test the latest RC version of LND. There are a lot of important fixes so thus expediting with RC: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.4-beta.rc1

This version also includes the ability to skip our auto initialization/unlocking of the LND wallet using `LND_SKIP_INITUNLOCK` environment variable. Once merged this will resolve the issue: https://github.com/btcpayserver/btcpayserver/issues/5612 

To test on your server connect with SSH and do:

```
git fetch
git checkout feat/lnd-v0.17.4-beta-rc1
btcpay-update.sh
```