### PR TITLE
Bumping LND to 0.17.4-beta

### DIFF
--- a/contrib/build-all-images.sh
+++ b/contrib/build-all-images.sh
@@ -128,12 +128,12 @@ DOCKERFILE="linuxamd64.Dockerfile"
 [[ "$(uname -m)" == "armv7l" ]] && DOCKERFILE="linuxarm32v7.Dockerfile"
 # https://raw.githubusercontent.com/btcpayserver/lnd/basedon-v0.17.3-beta/linuxarm64v8.Dockerfile
 [[ "$(uname -m)" == "aarch64" ]] && DOCKERFILE="linuxarm64v8.Dockerfile"
-echo "Building btcpayserver/lnd:v0.17.3-beta"
+echo "Building btcpayserver/lnd:v0.17.4-beta"
 git clone https://github.com/btcpayserver/lnd lnd
 cd lnd
 git checkout basedon-v0.17.3-beta
 cd "$(dirname $DOCKERFILE)"
-docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.3-beta" .
+docker build -f "$DOCKERFILE" -t "btcpayserver/lnd:v0.17.4-beta" .
 cd - && cd ..
 
 

--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   lnd_bitcoin:
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta
     container_name: btcpayserver_lnd_bitcoin
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Creating this PR for update to the latest version of LND. There are a lot of important fixes so thus expediting: https://github.com/lightningnetwork/lnd/releases/tag/v0.17.4-beta

There were occasional problems with this version:
- Flakiness in tests with Eclair - https://github.com/btcpayserver/BTCPayServer.Lightning/issues/159
- It failed integration testing in BTCPay Server several times - https://app.circleci.com/pipelines/github/btcpayserver/btcpayserver/12096/workflows/13032e8e-c602-4455-b5a2-ebf323ea38c1/jobs/37657

However, opening PR after talking with Nicolas so others can do testing on their machines and we have option to merge it.

To test on your server connect with SSH and do:

```
git fetch
git checkout feat/lnd-v0.17.4-beta
btcpay-update.sh
```