### PR TITLE
Add `trim_headers` to liquid-default-prune config

### DIFF
--- a/docker-compose-generator/docker-fragments/liquid-default-prune.yml
+++ b/docker-compose-generator/docker-fragments/liquid-default-prune.yml
@@ -5,3 +5,4 @@ services:
     environment:
       ELEMENTS_EXTRA_ARGS: |
         prune=5000
+        trim_headers=1


### PR DESCRIPTION
## Description

This activates the 'trim_headers' option to be even lighter on RAM when syncing and running the node ([details](https://blog.liquid.net/elements-22-1-1-optimize-your-node-for-lightweight-diy-hardware/)).

I ran into this issue when syncing a node on a lunanode m4 setup and this helped get me through resource contraint issues. I'm adding in the `liquid-default-prune.yml` file here, but tbd whether this makes more sense to be in the main `liquid.yml` file instead.