### PR TITLE
Update ubuntu image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   cansetup:
     machine:
       enabled: true
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run:


### PR DESCRIPTION
`ubuntu-2004:202101-01` is deprecated.
https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

So I update image of ubuntu.

This is the CircleCI results.
https://app.circleci.com/pipelines/github/wakiyamap/btcpayserver-docker/24/workflows/2db77ec5-8edf-4b03-b97c-645030165213/jobs/24

If it is `default`, the changes may be too large, so I set it to `current`.
https://circleci.com/docs/linux-vm-support-policy/