### PR TITLE
Add in option for btcpay_backup to backup full lnd state for migration

### DIFF
--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -41,7 +41,7 @@ END
 RESTART=true
 EXCLUDE_LND_GRAPH="volumes/generated_lnd_bitcoin_datadir/_data/data/graph"
 WARNING_LND_DIRE1A="🚨🚨🚨 LND is currently enabled and will be restarting 🚨🚨🚨"
-WARNING_LND_DIRE1B="🚨🚨🚨 LND is currently enabled and has been resarted 🚨🚨🚨"
+WARNING_LND_DIRE1B="🚨🚨🚨 LND is currently enabled and has been restarted 🚨🚨🚨"
 WARNING_LND_DIRE2="🚨🚨🚨 You cannot restore from this backup anywhere as is!!!  🚨🚨🚨"
 
 while (( "$#" )); do


### PR DESCRIPTION
The deleted line removes the failure to backup lnd database files channel.db and sphinxreplay.db.

Please see https://github.com/lightningnetwork/lnd/discussions/9070 for issue and discussion.

I suspect the next line should also be deleted for CLN:
```
    --exclude="volumes/generated_clightning_bitcoin_datadir/_data/lightning-rpc" \
```