### PR TITLE
Update bitcoin.yml to bitcoincore 28.1

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin.yml
@@ -4,7 +4,7 @@ services:
   bitcoind:
     restart: unless-stopped
     container_name: btcpayserver_bitcoind
-    image: btcpayserver/bitcoin:27.1
+    image: btcpayserver/bitcoin:28.1
     environment:
       BITCOIN_NETWORK: ${NBITCOIN_NETWORK:-regtest}
       CREATE_WALLET: "false"


### PR DESCRIPTION
Adds newest bitcoincore 28.1 to docker btcpayserver

Runnning since a while now, no problems. Anyone can test with this PR