### PR TITLE
Update liquid.yml change configs for peerswap compatibility

### DIFF
--- a/docker-compose-generator/docker-fragments/liquid.yml
+++ b/docker-compose-generator/docker-fragments/liquid.yml
@@ -20,7 +20,8 @@ services:
         whitelist=0.0.0.0/0
         rpcauth=liquid:c8bf1a8961d97f224cb21224aaa8235d$$402f4a8907683d057b8c58a42940b6e54d1638322a42986ae28ebb844e603ae6        
         validatepegin=0
-        fallbackfee=0.000001
+        acceptdiscountct=1
+        creatediscountct=1
     expose:
       - "43782"
       - "39388"


### PR DESCRIPTION
remove `fallbackfee` and add CT configs to regain peerswap compatibility:

https://github.com/ElementsProject/peerswap/issues/347

fallbackfee is not needed anymore in newer elements versions.

and adds new options to make peerswap work with new discountfee of elements

`acceptdiscountct=1`
`creatediscountct=1`

for elements 23.2.3 Discounted Fees for Confidential Transactions feature is available

https://blog.blockstream.com/elements-23-2-3-discounted-fees-for-confidential-transactions/