### PR TITLE
Add Phoenixd support

### DIFF
--- a/docker-compose-generator/crypto-definitions.json
+++ b/docker-compose-generator/crypto-definitions.json
@@ -4,83 +4,95 @@
     "CryptoFragment": "litecoin",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "btc",
     "CryptoFragment": "bitcoin",
     "CLightningFragment": "bitcoin-clightning",
     "LNDFragment": "bitcoin-lnd",
-    "EclairFragment": "bitcoin-eclair"
+    "EclairFragment": "bitcoin-eclair",
+    "PhoenixdFragment": "phoenixd"
   },
   {
     "Crypto": "btx",
     "CryptoFragment": "bitcore",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "btg",
     "CryptoFragment": "bgold",
     "CLightningFragment": null,
     "LNDFragment": "bgold-lnd",
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "ftc",
     "CryptoFragment": "feathercoin",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "grs",
     "CryptoFragment": "groestlcoin",
     "CLightningFragment": "groestlcoin-clightning",
     "LNDFragment": "groestlcoin-lnd",
-    "EclairFragment": "groestlcoin-eclair"
+    "EclairFragment": "groestlcoin-eclair",
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "via",
     "CryptoFragment": "viacoin",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "dash",
     "CryptoFragment": "dash",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "doge",
     "CryptoFragment": "dogecoin",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "mona",
     "CryptoFragment": "monacoin",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "xmr",
     "CryptoFragment": "monero",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   },
   {
     "Crypto": "lbtc",
     "CryptoFragment": "liquid",
     "CLightningFragment": null,
     "LNDFragment": null,
-    "EclairFragment": null
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   }
 ]

--- a/docker-compose-generator/docker-fragments/phoenixd.yml
+++ b/docker-compose-generator/docker-fragments/phoenixd.yml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+  phoenixd:
+    image: acinq/phoenixd:0.5.1
+    container_name: phoenixd
+    restart: unless-stopped
+    networks:
+      - default
+    command: ["--chain=${NBITCOIN_NETWORK:-regtest}"]
+    expose:
+      - "9740"
+    depends_on:
+      - btcpayserver
+    volumes:
+      - "phoenixd_datadir:/phoenix"
+
+volumes:
+  phoenixd_datadir:
+
+exclusive:
+  - lightning

--- a/docker-compose-generator/src/CryptoDefinition.cs
+++ b/docker-compose-generator/src/CryptoDefinition.cs
@@ -7,5 +7,6 @@
 		public string CLightningFragment { get; set; }
 		public string LNDFragment { get; set; }
 		public string EclairFragment { get; set; }
+		public string PhoenixdFragment { get; set; }
 	}
 }

--- a/docker-compose-generator/src/Program.cs
+++ b/docker-compose-generator/src/Program.cs
@@ -81,6 +81,10 @@ namespace DockerGenerator
 				{
 					fragments.Add(crypto.EclairFragment);
 				}
+				if (composition.SelectedLN == "phoenixd" && crypto.PhoenixdFragment != null)
+				{
+					fragments.Add(crypto.PhoenixdFragment);
+				}
 			}
 
 			foreach (var fragment in composition.AdditionalFragments)


### PR DESCRIPTION
This adds `phoenixd` as an official Lightning implementation:
```shell
export BTCPAYGEN_LIGHTNING="phoenixd"
```

We already have a working plugin, will publish shortly.
