### PR TITLE
Not redirecting acme-challange url

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -514,7 +514,19 @@ server {
 	listen [::]:80 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host$request_uri;
+
+	# Allow acme challenge requests without redirect
+	location ^~ /.well-known/acme-challenge/ {
+		allow all;
+		root /usr/share/nginx/html;
+		try_files $uri =404;
+		break;
+	}
+
+	# Redirect all other requests to HTTPS
+	location / {
+		return 301 https://$host$request_uri;
+	}
 }
 {{ end }}
 

--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -517,6 +517,8 @@ server {
 
 	# Allow acme challenge requests without redirect
 	location ^~ /.well-known/acme-challenge/ {
+		auth_basic off;
+		auth_request off;
 		allow all;
 		root /usr/share/nginx/html;
 		try_files $uri =404;


### PR DESCRIPTION
Let's Encrypt certificate renewal was failing because the ACME HTTP-01 validation challenge couldn't be completed. The validation servers attempt to access the /.well-known/acme-challenge/ path over HTTP, but our server was configured to redirect all HTTP traffic to HTTPS before completing the challenge verification.

It's possible that timer on Fractal's server we debugged was a bit off and that's why for him this problem kept recurring. While in most cases it must be done in a such a way that acme-challenge was being done while https was still functioning.

I've modified the nginx template to specifically allow HTTP access to the /.well-known/acme-challenge/ path while maintaining HTTPS redirection for all other traffic.