### PR TITLE
add knots as a bitcoind backend

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoinknots.yml
+++ b/docker-compose-generator/docker-fragments/bitcoinknots.yml
@@ -1,0 +1,46 @@
+version: "3"
+
+services:
+  bitcoind:
+    restart: unless-stopped
+    container_name: btcpayserver_bitcoind
+    image: ghcr.io/retropex/bitcoin:btcpay-28.1
+    environment:
+      BITCOIN_NETWORK: ${NBITCOIN_NETWORK:-regtest}
+      CREATE_WALLET: "false"
+      BITCOIN_WALLETDIR: "/walletdata"
+      # rpcport and rpcbind seems duplicates, but they are not
+      # rpcport is using by some tooling to automatically get
+      # the rpcport from the configuration file. Do not remove!
+      BITCOIN_EXTRA_ARGS: |
+        rpcport=43782
+        rpcbind=0.0.0.0:43782
+        rpcallowip=0.0.0.0/0
+        port=39388
+        whitelist=0.0.0.0/0
+        maxmempool=500
+    expose:
+      - "43782"
+      - "39388"
+    volumes:
+      - "bitcoin_datadir:/data"
+      - "bitcoin_wallet_datadir:/walletdata"
+  nbxplorer:
+    environment:
+      NBXPLORER_CHAINS: "btc"
+      NBXPLORER_BTCRPCURL: http://bitcoind:43782/
+      NBXPLORER_BTCNODEENDPOINT: bitcoind:39388
+    volumes:
+      - "bitcoin_datadir:/root/.bitcoin"
+  btcpayserver:
+    environment:
+      BTCPAY_CHAINS: "btc"
+      BTCPAY_BTCEXPLORERURL: http://nbxplorer:32838/
+volumes:
+  bitcoin_datadir:
+  bitcoin_wallet_datadir:
+
+exclusive:
+  - bitcoin-node
+recommended:
+  - "opt-mempoolfullrbf"

--- a/docker-compose-generator/docker-fragments/bitcoinknots.yml
+++ b/docker-compose-generator/docker-fragments/bitcoinknots.yml
@@ -4,7 +4,7 @@ services:
   bitcoind:
     restart: unless-stopped
     container_name: btcpayserver_bitcoind
-    image: ghcr.io/retropex/bitcoin:btcpay-28.1
+    image: btcpayserver/bitcoinknots:28.1
     environment:
       BITCOIN_NETWORK: ${NBITCOIN_NETWORK:-regtest}
       CREATE_WALLET: "false"


### PR DESCRIPTION
Hey,

I would need some help with this, I would like that if `export BTCPAYGEN_CRYPTO1="btc-knots"` is exported then knots is utilized as a backend.

The thing I don't understand where in `docker-compose-generator` the `btc`/`btc-knots` is interpreted.