### PR TITLE
Add Zcash fragment

### DIFF
--- a/docker-compose-generator/crypto-definitions.json
+++ b/docker-compose-generator/crypto-definitions.json
@@ -94,5 +94,13 @@
     "LNDFragment": null,
     "EclairFragment": null,
     "PhoenixdFragment": null
+  },
+  {
+    "Crypto": "zec",
+    "CryptoFragment": "zcash",
+    "CLightningFragment": null,
+    "LNDFragment": null,
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   }
 ]

--- a/docker-compose-generator/docker-fragments/zcash.yml
+++ b/docker-compose-generator/docker-fragments/zcash.yml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+  zcash_walletd:
+    restart: unless-stopped
+    image: 1337bytes/zcash-walletd:latest
+    environment:
+      NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=
+    expose:
+      - "8000"
+    volumes:
+    - "zec_wallet:/data"
+  btcpayserver:
+    environment:
+      BTCPAY_ZEC_DAEMON_URI: http://zcash_walletd:18090
+      BTCPAY_ZEC_WALLET_DAEMON_URI: http://zcash_walletd:18090
+      BTCPAY_ZEC_WALLET_DAEMON_WALLETDIR: /root/zec_wallet
+    volumes:
+      - "zec_wallet:/root/zec_wallet"
+volumes:
+  zec_wallet:
+  zec_data:


### PR DESCRIPTION
Note: uses a forked version of `zcash-walletd` with an external lightwallet server: `zecrocks.com`, as `zebra`/`lightwalletd` do not currently support pruned nodes.

A local or custom `lightwalletd` server URL can be passed in with the `LWD_URL` environment variable via an additional fragment. Example:

```yml
version: "3"

services:
  zcash_walletd:
    environment:
      LWD_URL: http://host.docker.internal:8232/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=
    extra_hosts:
      - host.docker.internal:host-gateway
required:
    - "zcash"

```