### PR TITLE
Bumping WooCommerce image; Ensure mariadb container is up and running.

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-woocommerce.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-woocommerce.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   woocommerce:
-    image: btcpayserver/woocommerce:3.1.0
+    image: btcpayserver/woocommerce:10.2.1
     environment:
       WOOCOMMERCE_HOST: ${WOOCOMMERCE_HOST}
       WORDPRESS_DB_HOST: mariadb
@@ -18,6 +18,9 @@ services:
       - mariadb
     volumes:
       - "woocommerce_html:/var/www/html"
+    depends_on:
+      mariadb:
+        condition: service_healthy
 
   mariadb:
     image: mariadb:10.11
@@ -31,6 +34,12 @@ services:
       - "3306"
     volumes:
       - "mariadb_datadir:/var/lib/mysql"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD --silent"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 12
 
   btcpayserver:
     environment:

--- a/docker-compose-generator/docker-fragments/opt-add-woocommerce.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-woocommerce.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   woocommerce:
-    image: btcpayserver/woocommerce:10.2.1
+    image: btcpayserver/woocommerce:10.2.2
     environment:
       WOOCOMMERCE_HOST: ${WOOCOMMERCE_HOST}
       WORDPRESS_DB_HOST: mariadb


### PR DESCRIPTION
Depends on this PR to be merged first: 
https://github.com/btcpayserver/dockerfile-deps/pull/123

What changed: 
- Update WooComemmerce to latest image 
- Make sure MariaDB is running and perform a healthcheck; it could happen that otherwise woocommerce container starts installation without db beeing ready