### PR TITLE
Upgrade zcash-walletd Docker image for Orchard

### DIFF
--- a/docker-compose-generator/docker-fragments/zcash-fullnode.yml
+++ b/docker-compose-generator/docker-fragments/zcash-fullnode.yml
@@ -1,10 +1,11 @@
 services:
   zcash_walletd:
     restart: unless-stopped
-    image: 1337bytes/zcash-walletd:0.0.2
+    image: hhanh00/zcash-walletd:latest
     environment:
       NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=
-      ROCKET_DB_PATH: /data/zec-wallet.db
+      ROCKET_DB_PATH: /data/zec-wallet2.db
+      CONFIG_PATH: /data/config2.json
       LWD_URL: http://lightwalletd:9067
     expose:
       - "8000"

--- a/docker-compose-generator/docker-fragments/zcash-fullnode.yml
+++ b/docker-compose-generator/docker-fragments/zcash-fullnode.yml
@@ -1,7 +1,7 @@
 services:
   zcash_walletd:
     restart: unless-stopped
-    image: hhanh00/zcash-walletd:latest
+    image: hhanh00/zcash-walletd:1.1.3
     environment:
       NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=
       ROCKET_DB_PATH: /data/zec-wallet2.db
@@ -22,7 +22,7 @@ services:
 
   zebra:
     container_name: zebra
-    image: zfnd/zebra
+    image: zfnd/zebra:2.5.0
     platform: linux/amd64
     restart: unless-stopped
     deploy:
@@ -42,7 +42,7 @@ services:
     #  - generated_default
 
   lightwalletd:
-    image: electriccoinco/lightwalletd
+    image: electriccoinco/lightwalletd:v0.4.18
     platform: linux/amd64
     depends_on:
       zebra:

--- a/docker-compose-generator/docker-fragments/zcash.yml
+++ b/docker-compose-generator/docker-fragments/zcash.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   zcash_walletd:
     restart: unless-stopped
-    image: hhanh00/zcash-walletd:latest
+    image: hhanh00/zcash-walletd:1.1.3
     environment:
       NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=
       ROCKET_DB_PATH: /data/zec-wallet2.db

--- a/docker-compose-generator/docker-fragments/zcash.yml
+++ b/docker-compose-generator/docker-fragments/zcash.yml
@@ -3,10 +3,11 @@ version: "3"
 services:
   zcash_walletd:
     restart: unless-stopped
-    image: 1337bytes/zcash-walletd:0.0.2
+    image: hhanh00/zcash-walletd:latest
     environment:
       NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=
-      ROCKET_DB_PATH: /data/zec-wallet.db
+      ROCKET_DB_PATH: /data/zec-wallet2.db
+      CONFIG_PATH: /data/config2.json
       LWD_URL: https://zec.rocks:443
     expose:
       - "8000"


### PR DESCRIPTION
A suffix has been added to the database and config path, since a fresh wallet database and viewing key are required. `zcash-walletd` will not start until a UFVK (with recent birth height) has been added in the Zcash plugin settings in the BTCPayServer admin dashboard. All existing merchants should be made aware of this change, and should already be using UA compatible wallets.

The birth height should be recent and not include any Sapling transactions.

```
      ROCKET_DB_PATH: /data/zec-wallet2.db
      CONFIG_PATH: /data/config2.json
```

Note that the `latest` image tag is now used rather than a fixed version – `image: hhanh00/zcash-walletd:latest`.