### PR TITLE
Add ZEC config path environment variable

### DIFF
--- a/docker-compose-generator/docker-fragments/zcash-fullnode.yml
+++ b/docker-compose-generator/docker-fragments/zcash-fullnode.yml
@@ -17,6 +17,7 @@ services:
       BTCPAY_ZEC_DAEMON_URI: http://zcash_walletd:8000
       BTCPAY_ZEC_WALLET_DAEMON_URI: http://zcash_walletd:8000
       BTCPAY_ZEC_WALLET_DAEMON_WALLETDIR: /root/zec_wallet
+      BTCPAY_ZEC_WALLET_DAEMON_CONFIG_PATH: /data/config2.json
     volumes:
       - "zec_wallet:/root/zec_wallet"
 

--- a/docker-compose-generator/docker-fragments/zcash.yml
+++ b/docker-compose-generator/docker-fragments/zcash.yml
@@ -18,6 +18,7 @@ services:
       BTCPAY_ZEC_DAEMON_URI: http://zcash_walletd:8000
       BTCPAY_ZEC_WALLET_DAEMON_URI: http://zcash_walletd:8000
       BTCPAY_ZEC_WALLET_DAEMON_WALLETDIR: /root/zec_wallet
+      BTCPAY_ZEC_WALLET_DAEMON_CONFIG_PATH: /data/config2.json
     volumes:
       - "zec_wallet:/root/zec_wallet"
 volumes:


### PR DESCRIPTION
Necessary fix for using the correct `config.json` file in the Zcash plugin after the Orchard support update.