### PR TITLE
Fix: Ungraceful shutdown of zcash and monero

### DIFF
--- a/docker-compose-generator/docker-fragments/monero.yml
+++ b/docker-compose-generator/docker-fragments/monero.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   monerod:
     restart: unless-stopped
+    init: true
     container_name: btcpayserver_monerod
     image: btcpayserver/monero:0.18.4.2
     command: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
@@ -12,6 +13,7 @@ services:
       - "xmr_data:/data"
   monerod_wallet:
     restart: unless-stopped
+    init: true
     container_name: btcpayserver_monero_wallet
     image: btcpayserver/monero:0.18.4.2
     command: monero-wallet-rpc --rpc-bind-ip=0.0.0.0 --disable-rpc-login --confirm-external-bind --rpc-bind-port=18082 --non-interactive --trusted-daemon  --daemon-address=monerod:18081 --wallet-file=/wallet/wallet --password-file=/wallet/password --tx-notify="/bin/sh ./scripts/notifier.sh  -X GET http://btcpayserver:49392/monerolikedaemoncallback/tx?cryptoCode=xmr&hash=%s"

--- a/docker-compose-generator/docker-fragments/zcash-fullnode.yml
+++ b/docker-compose-generator/docker-fragments/zcash-fullnode.yml
@@ -1,6 +1,7 @@
 services:
   zcash_walletd:
     restart: unless-stopped
+    init: true
     image: hhanh00/zcash-walletd:1.1.3
     environment:
       NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=

--- a/docker-compose-generator/docker-fragments/zcash.yml
+++ b/docker-compose-generator/docker-fragments/zcash.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   zcash_walletd:
     restart: unless-stopped
+    init: true
     image: hhanh00/zcash-walletd:1.1.3
     environment:
       NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=


### PR DESCRIPTION
Fix #1021 

When Monero or zcash wallets were shutdown, the last 20-ish generated addresses would be generated again on restart... this would make BTCPay Server crashing as there would be duplicate addresses. (duplicate `PK_AddressInvoices`)

Explained in [this comment](https://github.com/btcpayserver/btcpayserver-docker/issues/1021#issuecomment-3476365459).

We need to ping the monero guys to fix their image so people not using `init: true` doesn't end up corrupted.