### PR TITLE
Adding support for Nanocurrency (XNO) installation. 

### DIFF
--- a/docker-compose-generator/crypto-definitions.json
+++ b/docker-compose-generator/crypto-definitions.json
@@ -88,6 +88,14 @@
     "PhoenixdFragment": null
   },
   {
+    "Crypto": "xno",
+    "CryptoFragment": "nano",
+    "CLightningFragment": null,
+    "LNDFragment": null,
+    "EclairFragment": null,
+    "PhoenixdFragment": null
+  },
+  {
     "Crypto": "lbtc",
     "CryptoFragment": "liquid",
     "CLightningFragment": null,

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -35,7 +35,7 @@ services:
       - "~/PippinData:/root/PippinData"
     depends_on:
       - nano-node
-      - nano-work-gen
+      # - nano-work-gen
       - nano-pippin-redis
   nano-pippin-redis:
     container_name: btcpayserver_nano_pippin_redis

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -30,6 +30,8 @@ services:
     image: bananocoin/pippin:latest
     expose:
       - "11338"
+    environment: 
+      - REDIS_HOST: 'btcpayserver_nano_pippin_redis'
     volumes:
       - "~/PippinData:/root/PippinData"
     depends_on:

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -28,11 +28,10 @@ services:
     restart: unless-stopped
     container_name: btcpayserver_nano_pippin_wallet
     image: bananocoin/pippin:latest
-    # command: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
     expose:
       - "11338"
     volumes:
-      - "~:/root"
+      - "~/PippinData:/root/PippinData"
     depends_on:
       - nano-node
       - nano-work-gen

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -31,7 +31,7 @@ services:
     expose:
       - "11338"
     environment: 
-      - REDIS_HOST: 'btcpayserver_nano_pippin_redis'
+      REDIS_HOST: "btcpayserver_nano_pippin_redis"
     volumes:
       - "~/PippinData:/root/PippinData"
     depends_on:

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -12,7 +12,7 @@ services:
       - "7075"
     volumes:
       - "~:/root"
-  nano_work_gen:
+  nano-work-gen:
     restart: unless-stopped
     container_name: btcpayserver_nano_work_gen
     image: pbuyle/nano-work-server:nvidia
@@ -24,9 +24,28 @@ services:
     #   - "xmr_wallet:/wallet"
     depends_on:
       - nano-node
+  nano-pippin-wallet:
+    restart: unless-stopped
+    container_name: btcpayserver_nano_pippin_wallet
+    image: bananocoin/pippin:latest
+    # command: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
+    expose:
+      - "11338"
+    volumes:
+      - "~:/root"
+    depends_on:
+      - nano-node
+      - nano-work-gen
+      - nano-pippin-redis
+  nano-pippin-redis:
+    container_name: btcpayserver_nano_pippin_redis
+    image: redis:latest
+    restart: unless-stopped
+    expose:
+        - '6379'
   btcpayserver:
     environment:
-      BTCPAY_XNO_RPC_URI: http://nano-node:7076
-      BTCPAY_XNO_WEBSOCKET_URI: http://nano-node:7078
+      BTCPAY_XNO_RPC_URI: http://btcpayserver_nano_node:7076
+      BTCPAY_XNO_WEBSOCKET_URI: ws://btcpayserver_nano_node:7078
     # volumes:
     #   - "xmr_wallet:/root/xmr_wallet"

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -5,25 +5,24 @@ services:
     restart: unless-stopped
     container_name: btcpayserver_nano_node
     image: nanocurrency/nano:V28.2
-    # command: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
     expose:
       - "7076"
       - "7078"
       - "7075"
     volumes:
       - "~:/root"
-  nano-work-gen:
-    restart: unless-stopped
-    container_name: btcpayserver_nano_work_gen
-    image: pbuyle/nano-work-server:nvidia
-    # command: docker run --rm -p 127.0.0.1:7000:7000/tcp pbuyle/nano-work-server --cpu-threads 4 --listen-address 0.0.0.0:7000
-    expose: 
-      - "7000"
-    command: ["--cpu-threads", "4", "--listen-address", "0.0.0.0:7000"]
-    # volumes:
-    #   - "xmr_wallet:/wallet"
-    depends_on:
-      - nano-node
+  # nano-work-gen:
+  #   restart: unless-stopped
+  #   container_name: btcpayserver_nano_work_gen
+  #   image: pbuyle/nano-work-server:nvidia
+  #   # command: docker run --rm -p 127.0.0.1:7000:7000/tcp pbuyle/nano-work-server --cpu-threads 4 --listen-address 0.0.0.0:7000
+  #   expose: 
+  #     - "7000"
+  #   command: ["--cpu-threads", "4", "--listen-address", "0.0.0.0:7000"]
+  #   # volumes:
+  #   #   - "xmr_wallet:/wallet"
+  #   depends_on:
+  #     - nano-node
   nano-pippin-wallet:
     restart: unless-stopped
     container_name: btcpayserver_nano_pippin_wallet
@@ -48,5 +47,3 @@ services:
     environment:
       BTCPAY_XNO_RPC_URI: http://btcpayserver_nano_pippin_wallet:11338
       BTCPAY_XNO_WEBSOCKET_URI: ws://btcpayserver_nano_node:7078
-    # volumes:
-    #   - "xmr_wallet:/root/xmr_wallet"

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -46,7 +46,7 @@ services:
         - '6379'
   btcpayserver:
     environment:
-      BTCPAY_XNO_RPC_URI: http://btcpayserver_nano_node:7076
-      BTCPAY_XNO_WEBSOCKET_URI: ws://btcpayserver_nano_node:7078
+      BTCPAY_XNO_RPC_URI: http://btcpayserver_nano_pippin_wallet:11338
+      BTCPAY_XNO_WEBSOCKET_URI: ws://btcpayserver_nano_pippin_wallet:11338
     # volumes:
     #   - "xmr_wallet:/root/xmr_wallet"

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -47,6 +47,6 @@ services:
   btcpayserver:
     environment:
       BTCPAY_XNO_RPC_URI: http://btcpayserver_nano_pippin_wallet:11338
-      BTCPAY_XNO_WEBSOCKET_URI: ws://btcpayserver_nano_pippin_wallet:11338
+      BTCPAY_XNO_WEBSOCKET_URI: ws://btcpayserver_nano_node:7078
     # volumes:
     #   - "xmr_wallet:/root/xmr_wallet"

--- a/docker-compose-generator/docker-fragments/nano.yml
+++ b/docker-compose-generator/docker-fragments/nano.yml
@@ -1,0 +1,32 @@
+version: "3"
+
+services:
+  nano-node:
+    restart: unless-stopped
+    container_name: btcpayserver_nano_node
+    image: nanocurrency/nano:V28.2
+    # command: monerod --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --non-interactive --block-notify="/bin/sh ./scripts/notifier.sh -X GET http://btcpayserver:49392/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --hide-my-port --prune-blockchain --enable-dns-blocklist
+    expose:
+      - "7076"
+      - "7078"
+      - "7075"
+    volumes:
+      - "~:/root"
+  nano_work_gen:
+    restart: unless-stopped
+    container_name: btcpayserver_nano_work_gen
+    image: pbuyle/nano-work-server:nvidia
+    # command: docker run --rm -p 127.0.0.1:7000:7000/tcp pbuyle/nano-work-server --cpu-threads 4 --listen-address 0.0.0.0:7000
+    expose: 
+      - "7000"
+    command: ["--cpu-threads", "4", "--listen-address", "0.0.0.0:7000"]
+    # volumes:
+    #   - "xmr_wallet:/wallet"
+    depends_on:
+      - nano-node
+  btcpayserver:
+    environment:
+      BTCPAY_XNO_RPC_URI: http://nano-node:7076
+      BTCPAY_XNO_WEBSOCKET_URI: http://nano-node:7078
+    # volumes:
+    #   - "xmr_wallet:/root/xmr_wallet"


### PR DESCRIPTION
This PR: 

- Adds support for XNO. 

```
export BTCPAYGEN_CRYPTO1="xno"
```

This allows the setup script to install: 
- Nano Node
- Pippin Wallet
- Redis for Pippin
- Setup env vars for the Nano-Support Plugin. 

Additional Setup Docs for Nano support - https://gist.github.com/shriram-sg/e5f863aa096b3440a7f65b32d44ae908


