### PR TITLE
multi: Add Decred (DCR) support.

### DIFF
--- a/docker-compose-generator/crypto-definitions.json
+++ b/docker-compose-generator/crypto-definitions.json
@@ -110,5 +110,13 @@
     "LNDFragment": null,
     "EclairFragment": null,
     "PhoenixdFragment": null
+  },
+  {
+    "Crypto": "dcr",
+    "CryptoFragment": "decred",
+    "CLightningFragment": null,
+    "LNDFragment": null,
+    "EclairFragment": null,
+    "PhoenixdFragment": null
   }
 ]

--- a/docker-compose-generator/docker-fragments/decred.yml
+++ b/docker-compose-generator/docker-fragments/decred.yml
@@ -1,0 +1,23 @@
+services:
+  dcrwallet:
+    restart: unless-stopped
+    container_name: btcpayserver_dcrwallet
+    image: ghcr.io/bisoncraft/decred:2.1.5
+    command:
+      - dcrwallet
+      - --spv
+      - --username=btcpay
+      - --password=btcpay
+      - --rpclisten=0.0.0.0:9110
+      - --pass=${BTCPAY_DCR_WALLET_PASSPHRASE}
+    expose:
+      - "9110"
+    volumes:
+      - "dcr_wallet:/root/.dcrwallet"
+  btcpayserver:
+    environment:
+      BTCPAY_DCR_WALLET_URI: https://dcrwallet:9110
+      BTCPAY_DCR_RPC_USERNAME: btcpay
+      BTCPAY_DCR_RPC_PASSWORD: btcpay
+volumes:
+  dcr_wallet:

--- a/docker-compose-generator/docker-fragments/opt-decred-expose.yml
+++ b/docker-compose-generator/docker-fragments/opt-decred-expose.yml
@@ -1,0 +1,6 @@
+services:
+  dcrwallet:
+    ports:
+      - "127.0.0.1:9110:9110"
+required:
+  - "decred"


### PR DESCRIPTION
Adds compose fragments for running dcrwallet as an SPV wallet, connecting directly to the Decred P2P network without a full node. Requires the BTCPayServer Decred plugin for invoice and payment handling.