### PR TITLE
New switch-node.sh tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A wide variety of useful scripts are available once BTCPay is installed:
 * `. ./btcpay-setup.sh`: Information about additional parameters
 * `. ./btcpay-setup.sh -i`: Set up your BTCPayServer
 * `btcpay-restart.sh`: Restart your BTCPayServer
+* `switch-node.sh bitcoin|bitcoincore|bitcoinknots`: Switch your Bitcoin node implementation
 
 # Under the hood
 

--- a/contrib/build-all-images.sh
+++ b/contrib/build-all-images.sh
@@ -1283,3 +1283,19 @@ docker build -f "$DOCKERFILE" -t "hhanh00/zcash-walletd:1.1.5" .
 cd - && cd ..
 
 
+# Build bitcoin
+# https://raw.githubusercontent.com/btcpayserver/dockerfile-deps/Bitcoin/31.0/Bitcoin/31.0/linuxamd64.Dockerfile
+DOCKERFILE="Bitcoin/31.0/linuxamd64.Dockerfile"
+# https://raw.githubusercontent.com/btcpayserver/dockerfile-deps/Bitcoin/31.0/Bitcoin/31.0/linuxarm32v7.Dockerfile
+[[ "$(uname -m)" == "armv7l" ]] && DOCKERFILE="Bitcoin/31.0/linuxarm32v7.Dockerfile"
+# https://raw.githubusercontent.com/btcpayserver/dockerfile-deps/Bitcoin/31.0/Bitcoin/31.0/linuxarm64v8.Dockerfile
+[[ "$(uname -m)" == "aarch64" ]] && DOCKERFILE="Bitcoin/31.0/linuxarm64v8.Dockerfile"
+echo "Building btcpayserver/bitcoin:31.0"
+git clone https://github.com/btcpayserver/dockerfile-deps bitcoin
+cd bitcoin
+git checkout Bitcoin/31.0
+cd "$(dirname $DOCKERFILE)"
+docker build -f "$DOCKERFILE" -t "btcpayserver/bitcoin:31.0" .
+cd - && cd ..
+
+

--- a/docker-compose-generator/docker-fragments/bitcoincore.yml
+++ b/docker-compose-generator/docker-fragments/bitcoincore.yml
@@ -1,0 +1,46 @@
+services:
+  bitcoind:
+    restart: unless-stopped
+    container_name: btcpayserver_bitcoind
+    image: btcpayserver/bitcoin:31.0
+    environment:
+      BITCOIN_NETWORK: ${NBITCOIN_NETWORK:-regtest}
+      CREATE_WALLET: "false"
+      BITCOIN_WALLETDIR: "/walletdata"
+      # rpcport and rpcbind seems duplicates, but they are not
+      # rpcport is using by some tooling to automatically get
+      # the rpcport from the configuration file. Do not remove!
+      BITCOIN_EXTRA_ARGS: |
+        rpcport=43782
+        rpcbind=0.0.0.0:43782
+        rpcallowip=0.0.0.0/0
+        port=39388
+        whitelist=0.0.0.0/0
+        maxmempool=500
+    expose:
+      - "43782"
+      - "39388"
+    volumes:
+      - "bitcoin_datadir:/data"
+      - "bitcoin_wallet_datadir:/walletdata"
+  nbxplorer:
+    environment:
+      NBXPLORER_CHAINS: "btc"
+      NBXPLORER_BTCRPCURL: http://bitcoind:43782/
+      NBXPLORER_BTCNODEENDPOINT: bitcoind:39388
+    volumes:
+      - "bitcoin_datadir:/root/.bitcoin"
+  btcpayserver:
+    environment:
+      BTCPAY_CHAINS: "btc"
+      BTCPAY_BTCEXPLORERURL: http://nbxplorer:32838/
+volumes:
+  bitcoin_datadir:
+  bitcoin_wallet_datadir:
+
+exclusive:
+  - bitcoin-node
+recommended:
+  - "opt-mempoolfullrbf"
+required:
+  - "nbxplorer"

--- a/helpers.sh
+++ b/helpers.sh
@@ -27,6 +27,7 @@ install_tooling() {
                 "*" "btcpay-down.sh" "Command line for stopping all services related to BTCPay Server" \
                 "*" "btcpay-restart.sh" "Command line for restarting all services related to BTCPay Server" \
                 "*" "btcpay-setup.sh" "Command line for restarting all services related to BTCPay Server" \
+                "*" "switch-node.sh" "Command line for switching the Bitcoin node implementation" \
                 "*" "btcpay-up.sh" "Command line for starting all services related to BTCPay Server" \
                 "*" "btcpay-admin.sh" "Command line for some administrative operation in BTCPay Server" \
                 "*" "btcpay-update.sh" "Command line for updating your BTCPay Server to the latest commit of this repository" \

--- a/switch-node.sh
+++ b/switch-node.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+    cat <<-END
+Usage: switch-node.sh default|bitcoincore|bitcoinknots
+
+The default Bitcoin node implementation is selected by the BTCPay Server team.
+This is currently Bitcoin Core 29.x and is planned to move to Bitcoin Core 31.0 later.
+Use bitcoincore or bitcoinknots to explicitly pin your deployment to one of those implementations.
+END
+}
+
+node="$1"
+
+case "$node" in
+    default|bitcoincore|bitcoinknots)
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	# Mac OS
+	BASH_PROFILE_SCRIPT="$HOME/btcpay-env.sh"
+
+else
+	# Linux
+	BASH_PROFILE_SCRIPT="/etc/profile.d/btcpay-env.sh"
+fi
+
+remove_fragments() {
+    local value="$1"
+    local result=""
+    local fragment
+
+    value="${value//,/;}"
+    IFS=';' read -ra fragments <<< "$value"
+    for fragment in "${fragments[@]}"; do
+        fragment="${fragment//[[:space:]]/}"
+        case "$fragment" in
+            ""|bitcoin|bitcoincore|bitcoinknots)
+                continue
+                ;;
+        esac
+
+        if [ -z "$result" ]; then
+            result="$fragment"
+        else
+            result="$result;$fragment"
+        fi
+    done
+
+    echo "$result"
+}
+
+append_fragment() {
+    local value="$1"
+    local fragment="$2"
+
+    if [ -z "$value" ]; then
+        echo "$fragment"
+    else
+        echo "$value;$fragment"
+    fi
+}
+
+BTCPAYGEN_ADDITIONAL_FRAGMENTS="$(remove_fragments "$BTCPAYGEN_ADDITIONAL_FRAGMENTS")"
+BTCPAYGEN_EXCLUDE_FRAGMENTS="$(remove_fragments "$BTCPAYGEN_EXCLUDE_FRAGMENTS")"
+
+if [ "$node" != "default" ]; then
+    BTCPAYGEN_EXCLUDE_FRAGMENTS="$(append_fragment "$BTCPAYGEN_EXCLUDE_FRAGMENTS" "bitcoin")"
+    BTCPAYGEN_ADDITIONAL_FRAGMENTS="$(append_fragment "$BTCPAYGEN_ADDITIONAL_FRAGMENTS" "$node")"
+fi
+
+export BTCPAYGEN_ADDITIONAL_FRAGMENTS
+export BTCPAYGEN_EXCLUDE_FRAGMENTS
+
+echo "Switching Bitcoin node implementation to $node"
+. btcpay-setup.sh -i


### PR DESCRIPTION
### New switch-node.sh tool

```bash
Usage: switch-node.sh default|bitcoincore|bitcoinknots

The default Bitcoin node implementation is selected by the BTCPay Server team.
This is currently Bitcoin Core 29.x and is planned to move to Bitcoin Core 31.0 later.
Use bitcoincore or bitcoinknots to explicitly pin your deployment to one of those implementations.
```

The current versions in the docker fragments are:

| Node | Version | Docker Fragment |
|--------|--------|--------|
| default | btcpayserver/bitcoin:29.2 | [bitcoin.yml](https://github.com/btcpayserver/btcpayserver-docker/blob/master/docker-compose-generator/docker-fragments/bitcoin.yml) |
| bitcoincore | btcpayserver/bitcoin:31.0 | [bitcoincore.yml](https://github.com/btcpayserver/btcpayserver-docker/blob/master/docker-compose-generator/docker-fragments/bitcoincore.yml) |
| bitcoinknots | btcpayserver/bitcoinknots:29.3.knots20260210 | [bitcoinknots.yml](https://github.com/btcpayserver/btcpayserver-docker/blob/master/docker-compose-generator/docker-fragments/bitcoinknots.yml) |

`default` is expected to follow bitcoincore from version BTCPayServer 2.5.0.