### PR TITLE
Update zcash-walletd to 1.1.9

### DIFF
--- a/docker-compose-generator/docker-fragments/zcash.yml
+++ b/docker-compose-generator/docker-fragments/zcash.yml
@@ -2,7 +2,7 @@ services:
   zcash_walletd:
     restart: unless-stopped
     init: true
-    image: hhanh00/zcash-walletd:1.1.5
+    image: hhanh00/zcash-walletd:1.1.9
     environment:
       NOTIFY_TX_URL: http://btcpayserver:49392/zcashlikedaemoncallback/tx?cryptoCode=zec&hash=
       ROCKET_DB_PATH: /data/zec-wallet2.db


### PR DESCRIPTION
Update `zcash-walletd` to 1.1.9 for NU 6.2 support.