### PR TITLE
nginx.tmpl: warn about containers with VIRTUAL_HOST but no VIRTUAL_HOST_NAME

### DIFF
--- a/Production/nginx.tmpl
+++ b/Production/nginx.tmpl
@@ -390,6 +390,21 @@ server {
 }
 {{ end }}
 
+{{/*
+	Unlike upstream nginx-proxy, this template groups upstreams by
+	VIRTUAL_HOST_NAME instead of VIRTUAL_HOST. A container that only defines
+	VIRTUAL_HOST is not routed at all: its hosts fall through to the default
+	server above and return 503, with no hint as to why. Surface such
+	containers here so the misconfiguration is visible in the generated file.
+*/}}
+{{ range $container := whereExist (whereNotExist $ "Env.VIRTUAL_HOST_NAME") "Env.VIRTUAL_HOST" }}
+# WARNING: container "{{ $container.Name }}" defines VIRTUAL_HOST={{ $container.Env.VIRTUAL_HOST }}
+# but not VIRTUAL_HOST_NAME, so it is NOT routed and requests for its host(s)
+# return the default 503. Unlike upstream nginx-proxy, this template also
+# requires VIRTUAL_HOST_NAME (a short name, unique per upstream) on the
+# container.
+{{ end }}
+
 {{ range $host_name, $containers := groupByMulti $ "Env.VIRTUAL_HOST_NAME" "," }}
 
 {{ $host_name := trim $host_name }}


### PR DESCRIPTION
## Problem

`Production/nginx.tmpl` groups upstreams by `VIRTUAL_HOST_NAME`, unlike upstream nginx-proxy which keys everything on `VIRTUAL_HOST`. A container that only sets `VIRTUAL_HOST` (the convention documented everywhere for nginx-proxy) is silently dropped from the generated config:

- docker-gen logs `Contents of /etc/nginx/conf.d/default.conf did not change`,
- nginx keeps answering the catch-all `return 503` for that host,
- and nothing in any log or generated file explains why.

Since `VIRTUAL_HOST_NAME` is not mentioned in the README or the docs, this is an easy trap for anyone exposing an additional container through the BTCPay nginx stack, and it plausibly accounts for a share of the recurring "503 Service Temporarily Unavailable" issues (e.g. #247).

## Change

Emit a comment block at the top of the upstream section for any container that defines `VIRTUAL_HOST` without `VIRTUAL_HOST_NAME`:

```
# WARNING: container "myapp" defines VIRTUAL_HOST=app.example.com
# but not VIRTUAL_HOST_NAME, so it is NOT routed and requests for its host(s)
# return the default 503. Unlike upstream nginx-proxy, this template also
# requires VIRTUAL_HOST_NAME (a short name, unique per upstream) on the
# container.
```

`/etc/nginx/conf.d/default.conf` is the first place people look when debugging an unexpected 503, so the misconfiguration becomes self-diagnosing. Comments only — nginx behavior is unchanged.

## Testing

Rendered with `btcpayserver/docker-gen:0.10.7` against a live production BTCPay stack (19 containers, docker socket + tor/certs volumes mounted like `nginx-gen` does):

- healthy stack: output is **byte-identical** before/after this patch;
- after adding a container with only `VIRTUAL_HOST=test.example.invalid`: master renders **byte-identical output again** (confirming the silent drop), the patched template renders the same config plus exactly the warning block above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)