### PR TITLE
Allow overriding or disabling Let's Encrypt hosts via BTCPAY_LETSENCRYPT_HOSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Check out this video if you're interested in learning more about setting up [BTC
 * `BTCPAYGEN_SUBNAME`: The subname of the generated docker-compose file, where the full name is `Generated/docker-compose.SUBNAME.yml` (Default: `generated`)
 * `BTCPAYGEN_ADDITIONAL_FRAGMENTS`: Semicolon-separated list of additional fragments you want to use (eg. `opt-save-storage`)
 * `LETSENCRYPT_EMAIL`: An email will be sent to this address if certificate expires and fails to renew automatically (eg. `me@example.com`)
+* `BTCPAY_LETSENCRYPT_HOSTS`: Optional, comma-separated subset of your hosts to request a Let's Encrypt certificate for. Set to an empty string (`export BTCPAY_LETSENCRYPT_HOSTS=""`) to disable Let's Encrypt entirely, for example when TLS certificates are provisioned out of band (Cloudflare Origin CA, corporate CA, ...). When unset, certificates are requested for `BTCPAY_HOST` and `BTCPAY_ADDITIONAL_HOSTS`, as before.
 * `ACME_CA_URI`: The API endpoint to ask for HTTPS certificate (Default: `production`)
 * `BTCPAY_ENABLE_SSH`: Optional, gives BTCPay Server SSH access to the host by allowing it to edit authorized_keys of the host, it can be used for managing the authorized_keys or updating BTCPay Server directly through the website. (Default: false)
 * `BTCPAYGEN_DOCKER_IMAGE`: Optional, Specify which generator image to use if you have customized the C# generator. Set to `btcpayserver/docker-compose-generator:local` to build the generator locally at runtime.

--- a/btcpay-setup.sh
+++ b/btcpay-setup.sh
@@ -357,6 +357,13 @@ if cat \"\$BTCPAY_ENV_FILE\" &> /dev/null; then
 fi
 " > ${BASH_PROFILE_SCRIPT}
 
+# Contrary to the other environment variables, an empty BTCPAY_LETSENCRYPT_HOSTS and an unset one
+# behave differently (empty disables Let's Encrypt, unset requests certificates for all hosts),
+# so only save it when it is explicitly set.
+if [[ "${BTCPAY_LETSENCRYPT_HOSTS+x}" ]]; then
+    echo "export BTCPAY_LETSENCRYPT_HOSTS=\"$BTCPAY_LETSENCRYPT_HOSTS\"" >> ${BASH_PROFILE_SCRIPT}
+fi
+
 chmod +x ${BASH_PROFILE_SCRIPT}
 
 echo -e "BTCPay Server environment variables successfully saved in $BASH_PROFILE_SCRIPT\n"

--- a/docker-compose-generator/docker-fragments/btcpayserver-nginx.yml
+++ b/docker-compose-generator/docker-fragments/btcpayserver-nginx.yml
@@ -10,5 +10,9 @@ services:
       SSL_POLICY: Mozilla-Modern
 
       # Let's encrypt settings
-      LETSENCRYPT_HOST: ${BTCPAY_HOST},${BTCPAY_ADDITIONAL_HOSTS}
+      # BTCPAY_LETSENCRYPT_HOSTS narrows which hosts a certificate is
+      # requested for; setting it to an empty string disables Let's Encrypt
+      # entirely (e.g. when certificates are provisioned out of band).
+      # When unset, all hosts get a certificate, as before.
+      LETSENCRYPT_HOST: ${BTCPAY_LETSENCRYPT_HOSTS-${BTCPAY_HOST},${BTCPAY_ADDITIONAL_HOSTS}}
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL:-<no value>}


### PR DESCRIPTION
## Problem

There is no supported way to run the nginx reverse proxy while opting out of (or narrowing) Let's Encrypt issuance — needed when certificates are provisioned out of band (Cloudflare Origin CA, corporate CA, DNS-01 wildcards) or when a host is not publicly reachable for HTTP-01.

Working around it is currently painful because:

- `LETSENCRYPT_HOST` can't be overridden by a custom fragment — the generator **concatenates** duplicate environment keys across fragments (`DockerComposeDefinition.Merge`), so an override fragment just appends;
- `btcpayserver-nginx` can't go into `BTCPAYGEN_EXCLUDE_FRAGMENTS` — it's `required` by `nginx` and also carries `VIRTUAL_HOST`/routing;
- the only remaining option is editing the fragment in-place and protecting it with `git update-index --skip-worktree` so `btcpay-update.sh`'s `git pull --force` doesn't revert it — fragile and invisible.

## Change

Wrap the existing value in a compose-time variable default in `btcpayserver-nginx.yml`:

```yaml
LETSENCRYPT_HOST: ${BTCPAY_LETSENCRYPT_HOSTS-${BTCPAY_HOST},${BTCPAY_ADDITIONAL_HOSTS}}
```

- **unset** (every existing deployment): resolves to `$BTCPAY_HOST,$BTCPAY_ADDITIONAL_HOSTS` — byte-for-byte today's behavior;
- **set to a comma-separated list**: certificates are requested only for those hosts;
- **set to an empty string**: `LETSENCRYPT_HOST` is empty, and the companion's `letsencrypt_service_data` template (`{{ if trim $hosts }}`) skips the container entirely — issuance disabled, routing and `SSL_POLICY` untouched.

The dash (unset-only) form of the default is used deliberately so that an explicitly empty value is honored rather than replaced by the default. `BTCPAY_LETSENCRYPT_HOSTS` is intentionally **not** added to the persisted env in `btcpay_update_docker_env` — persisting it would turn "unset" into "set to empty" for every deployment and disable issuance globally.

Also documents the new variable in the README next to `LETSENCRYPT_EMAIL`.

## Compatibility & testing

Nested substitution in defaults requires Compose v2; `helpers.sh` already pins docker-compose 2.40.3.

Verified by running the generator (`build.sh` with `BTCPAYGEN_CRYPTO1=btc BTCPAYGEN_REVERSEPROXY=nginx BTCPAYGEN_LIGHTNING=clightning`) — the expression passes through to the generated compose unmangled — and then `docker compose config` on the generated file in all three states, with both Compose v5.1.3 and the pinned 2.40.3:

| state | rendered `LETSENCRYPT_HOST` |
|---|---|
| unset | `example.com,extra.example.com` |
| `sub.example.com` | `sub.example.com` |
| `""` | `""` |

The empty-string handling of the companion was verified against the `letsencrypt_service_data.tmpl` shipped in `btcpayserver/letsencrypt-nginx-proxy-companion:2.2.9-2`: containers whose `LETSENCRYPT_HOST` trims to empty are excluded from `LETSENCRYPT_CONTAINERS`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)