### PR TITLE
Improving backup and restore scripts

### DIFF
--- a/btcpay-backup.sh
+++ b/btcpay-backup.sh
@@ -1,156 +1,412 @@
-#!/bin/bash -e
+#!/bin/bash
 
-set -o pipefail -o errexit
+set -Eeuo pipefail
+
+# Backups can contain database dumps, wallet data, and other secrets.
+umask 077
 
 # Please be aware of these important issues:
 #
-# - Old channel state is toxic and you can loose all your funds, if you or someone
+# - Old channel state is toxic and you can lose all your funds, if you or someone
 #   else closes a channel based on the backup with old state - and the state changes
 #   often! If you publish an old state (say from yesterday's backup) on chain, you
 #   WILL LOSE ALL YOUR FUNDS IN A CHANNEL, because the counterparty will publish a
 #   revocation key!
 
-if [ "$(id -u)" != "0" ]; then
-  printf "\n🚨 This script must be run as root.\n"
-  printf "➡️  Use the command 'sudo su -' (include the trailing hypen) and try again.\n\n"
-  exit 1
-fi
+backup_dir=""
+backup_path=""
+btcpay_dir=""
+btcpay_stopped=false
+database_ready_timeout=""
+docker_dir=""
+compose_services=""
+mariadb_container=""
+mariadb_dump_name=""
+mariadb_dump_path=""
+postgres_container=""
+postgres_dump_name="postgres.sql.gz"
+postgres_dump_path=""
+temporary_backup_path=""
+work_dir=""
 
-# preparation
-if [[ "$OSTYPE" == "darwin"* ]]; then
-	# Mac OS
-	BASH_PROFILE_SCRIPT="$HOME/btcpay-env.sh"
-else
-	# Linux
-	BASH_PROFILE_SCRIPT="/etc/profile.d/btcpay-env.sh"
-fi
-
-. "$BASH_PROFILE_SCRIPT"
-
-docker_dir=$(docker volume inspect generated_btcpay_datadir --format="{{.Mountpoint}}" | sed -e "s%/volumes/.*%%g")
-postgres_dump_name=postgres.sql.gz
-btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
-backup_dir="$docker_dir/volumes/backup_datadir/_data"
-postgres_dump_path="$docker_dir/$postgres_dump_name"
-backup_path="$backup_dir/backup.tar.gz"
-
-# ensure backup dir exists
-if [ ! -d "$backup_dir" ]; then
-  mkdir -p $backup_dir
-fi
-
-cd $btcpay_dir
-. helpers.sh
-
-# Postgres database
-postgres_container=$(docker ps -a -q -f "name=postgres_1")
-if [ -z "$postgres_container" ]; then
-  printf "\n"
-  echo "ℹ️ Postgres container is not up and running. Starting BTCPay Server …"
-  docker volume create generated_postgres_datadir
-  docker-compose -f $BTCPAY_DOCKER_COMPOSE up -d postgres
-
-  printf "\n"
-  postgres_container=$(docker ps -a -q -f "name=postgres_1")
-  if [ -z "$postgres_container" ]; then
-    echo "🚨 Postgres container could not be started or found."
-    exit 1
-  fi
-fi
-
-printf "\n"
-echo "ℹ️ Dumping Postgres database …"
-{
-  docker exec $postgres_container pg_dumpall -c -U postgres | gzip > $postgres_dump_path
-  echo "✅ Postgres database dump done."
-} || {
-  echo "🚨 Dumping Postgres database failed. Please check the error message above."
+fail() {
+  printf "\n🚨 %s\n" "$1" >&2
   exit 1
 }
 
-# Optional: MariaDB database
-mariadb_container=$(docker ps -a -q -f "name=mariadb_1")
-if [ ! -z "$mariadb_container" ]; then
-  mariadb_dump_name=mariadb.sql.gz
-  mariadb_dump_path="$docker_dir/$mariadb_dump_name"
-  # MariaDB container exists and is running - dump it
-  printf "\n"
-  echo "ℹ️ Dumping MariaDB database …"
-  {
-    docker exec $mariadb_container mysqldump -u root -pwordpressdb -A --add-drop-database | gzip > $mariadb_dump_path
-    echo "✅ MariaDB database dump done."
-  } || {
-    echo "🚨 Dumping MariaDB database failed. Please check the error message above."
-    exit 1
-  }
+cleanup_temporary_files() {
+  local cleanup_failed=false
+  local path
+
+  for path in "$temporary_backup_path" "$postgres_dump_path" "$mariadb_dump_path"; do
+    if [ -n "$path" ] && { [ -e "$path" ] || [ -L "$path" ]; }; then
+      if ! rm -f -- "$path"; then
+        printf "⚠️ Could not remove temporary file %s.\n" "$path" >&2
+        cleanup_failed=true
+      fi
+    fi
+  done
+
+  if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+    if [ -z "$backup_dir" ] ||
+        [ "$(dirname "$work_dir")" != "$backup_dir" ] ||
+        [[ "$(basename "$work_dir")" != .btcpay-backup.* ]]; then
+      printf "⚠️ Refusing to clean unexpected temporary directory %s.\n" "$work_dir" >&2
+      cleanup_failed=true
+    elif ! rmdir -- "$work_dir"; then
+      printf "⚠️ Could not remove temporary directory %s.\n" "$work_dir" >&2
+      cleanup_failed=true
+    fi
+  fi
+
+  [ "$cleanup_failed" = false ]
+}
+
+cleanup_on_exit() {
+  local status=$?
+  local cleanup_failed=false
+
+  trap - EXIT
+
+  if [ "$btcpay_stopped" = true ] && [ -n "$btcpay_dir" ]; then
+    printf "\nℹ️ Restarting BTCPay Server after failed backup …\n\n" >&2
+    if (cd "$btcpay_dir" && btcpay_up); then
+      btcpay_stopped=false
+    else
+      printf "⚠️ BTCPay Server could not be restarted automatically. Run btcpay-up.sh before continuing.\n" >&2
+      cleanup_failed=true
+    fi
+  fi
+
+  if ! cleanup_temporary_files; then
+    cleanup_failed=true
+  fi
+
+  if [ "$status" -eq 0 ] && [ "$cleanup_failed" = true ]; then
+    status=1
+  fi
+
+  exit "$status"
+}
+
+wait_for_postgres() {
+  local container=$1
+  local elapsed
+
+  for ((elapsed = 0; elapsed < database_ready_timeout; elapsed++)); do
+    if docker exec "$container" pg_isready --quiet --username=postgres >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_mariadb() {
+  local container=$1
+  local elapsed
+
+  for ((elapsed = 0; elapsed < database_ready_timeout; elapsed++)); do
+    if docker exec "$container" mysqladmin --user=root --password=wordpressdb --silent ping >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+get_compose_container() {
+  local service=$1
+  local container
+
+  if ! container=$(docker-compose -f "$BTCPAY_DOCKER_COMPOSE" ps -q "$service"); then
+    fail "Could not inspect the $service container."
+  fi
+  if [[ "$container" == *$'\n'* ]]; then
+    fail "Expected exactly one $service container."
+  fi
+
+  printf "%s" "$container"
+}
+
+compose_has_service() {
+  local service=$1
+  local configured_service
+
+  while IFS= read -r configured_service; do
+    if [ "$configured_service" = "$service" ]; then
+      return 0
+    fi
+  done <<<"$compose_services"
+
+  return 1
+}
+
+ensure_postgres_ready() {
+  postgres_container=$(get_compose_container postgres)
+
+  if [ -z "$postgres_container" ]; then
+    printf "\nℹ️ Postgres container is not up and running. Starting it …\n\n"
+    if ! docker volume create generated_postgres_datadir >/dev/null; then
+      fail "Could not create the generated_postgres_datadir Docker volume."
+    fi
+    if ! docker-compose -f "$BTCPAY_DOCKER_COMPOSE" up -d postgres; then
+      fail "Starting the Postgres database container failed."
+    fi
+    postgres_container=$(get_compose_container postgres)
+  fi
+
+  if [ -z "$postgres_container" ]; then
+    fail "Postgres container could not be started or found."
+  fi
+  if ! wait_for_postgres "$postgres_container"; then
+    fail "Postgres did not become ready within $database_ready_timeout seconds."
+  fi
+}
+
+ensure_mariadb_ready() {
+  mariadb_container=$(get_compose_container mariadb)
+
+  if [ -z "$mariadb_container" ]; then
+    printf "\nℹ️ MariaDB container is not up and running. Starting it …\n\n"
+    if ! docker volume create generated_mariadb_datadir >/dev/null; then
+      fail "Could not create the generated_mariadb_datadir Docker volume."
+    fi
+    if ! docker-compose -f "$BTCPAY_DOCKER_COMPOSE" up -d mariadb; then
+      fail "Starting the MariaDB database container failed."
+    fi
+    mariadb_container=$(get_compose_container mariadb)
+  fi
+
+  if [ -z "$mariadb_container" ]; then
+    fail "MariaDB container could not be started or found."
+  fi
+  if ! wait_for_mariadb "$mariadb_container"; then
+    fail "MariaDB did not become ready within $database_ready_timeout seconds."
+  fi
+}
+
+trap cleanup_on_exit EXIT
+
+if [ "$(id -u)" -ne 0 ]; then
+  printf "\n🚨 This script must be run as root.\n"
+  printf "➡️ Use the command 'sudo su -' (include the trailing hyphen) and try again.\n\n"
+  exit 1
 fi
 
-# BTCPay Server backup
+# Load the BTCPay environment when the caller has not already done so.
+if [[ "${OSTYPE:-}" == darwin* ]]; then
+  bash_profile_script="${HOME:?}/btcpay-env.sh"
+else
+  bash_profile_script="/etc/profile.d/btcpay-env.sh"
+fi
+if [ -f "$bash_profile_script" ]; then
+  # shellcheck source=/dev/null
+  . "$bash_profile_script"
+fi
+
+if [ -z "${BTCPAY_BASE_DIRECTORY:-}" ]; then
+  fail "BTCPAY_BASE_DIRECTORY is not set."
+fi
+if [ -z "${BTCPAY_DOCKER_COMPOSE:-}" ]; then
+  fail "BTCPAY_DOCKER_COMPOSE is not set."
+fi
+if [ -z "${BTCPAY_ENV_FILE:-}" ]; then
+  fail "BTCPAY_ENV_FILE is not set."
+fi
+database_ready_timeout="${BTCPAY_DATABASE_READY_TIMEOUT:-60}"
+if ! [[ "$database_ready_timeout" =~ ^[1-9][0-9]*$ ]]; then
+  fail "BTCPAY_DATABASE_READY_TIMEOUT must be a positive number of seconds."
+fi
+
+btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
+backup_passphrase="${BTCPAY_BACKUP_PASSPHRASE:-}"
+
+if [ ! -d "$btcpay_dir" ] || [ ! -f "$btcpay_dir/helpers.sh" ]; then
+  fail "BTCPay Server directory $btcpay_dir is missing or incomplete."
+fi
+if [ ! -f "$BTCPAY_DOCKER_COMPOSE" ]; then
+  fail "Docker Compose file $BTCPAY_DOCKER_COMPOSE does not exist."
+fi
+
+if ! btcpay_mountpoint=$(docker volume inspect generated_btcpay_datadir --format='{{.Mountpoint}}'); then
+  fail "Could not inspect the generated_btcpay_datadir Docker volume."
+fi
+if [ -z "$btcpay_mountpoint" ] || [ "$btcpay_mountpoint" = "/" ]; then
+  fail "Docker returned an unsafe BTCPay volume mountpoint."
+fi
+
+btcpay_volume_dir=$(dirname "$btcpay_mountpoint")
+if [ "$(basename "$btcpay_mountpoint")" != "_data" ] ||
+    [ "$(basename "$btcpay_volume_dir")" != "generated_btcpay_datadir" ]; then
+  fail "Docker returned an unexpected BTCPay volume mountpoint: $btcpay_mountpoint"
+fi
+
+volumes_dir=$(dirname "$btcpay_volume_dir")
+if [ -z "$volumes_dir" ] || [ "$volumes_dir" = "/" ] || [ "$volumes_dir" = "." ]; then
+  fail "Could not determine a safe Docker volumes directory."
+fi
+docker_dir=$(dirname "$volumes_dir")
+if [ -z "$docker_dir" ] || [ "$docker_dir" = "/" ] || [ "$docker_dir" = "." ]; then
+  fail "Could not determine a safe Docker directory."
+fi
+
+backup_dir="$volumes_dir/backup_datadir/_data"
+plain_backup_path="$backup_dir/backup.tar.gz"
+backup_path="$plain_backup_path"
+if [ -n "$backup_passphrase" ]; then
+  backup_path="$plain_backup_path.gpg"
+fi
+
+if ! mkdir -p -- "$backup_dir"; then
+  fail "Could not create backup directory $backup_dir."
+fi
+if ! work_dir=$(mktemp -d "$backup_dir/.btcpay-backup.XXXXXX"); then
+  fail "Could not create a temporary backup directory in $backup_dir."
+fi
+postgres_dump_path="$work_dir/$postgres_dump_name"
+
+cd "$btcpay_dir"
+# shellcheck source=/dev/null
+. ./helpers.sh
+
+if ! compose_services=$(docker-compose -f "$BTCPAY_DOCKER_COMPOSE" config --services); then
+  fail "Could not inspect Docker Compose services."
+fi
+if ! compose_has_service postgres; then
+  fail "The Docker Compose file does not define a postgres service."
+fi
+
+ensure_postgres_ready
+
+printf "\nℹ️ Dumping Postgres database …\n"
+if ! docker exec "$postgres_container" pg_dumpall -c -U postgres |
+    gzip >"$postgres_dump_path"; then
+  fail "Dumping Postgres database failed. Please check the error above."
+fi
+if ! gzip -t -- "$postgres_dump_path"; then
+  fail "Postgres dump is corrupt or incomplete."
+fi
+printf "✅ Postgres database dump done.\n"
+
+if compose_has_service mariadb; then
+  mariadb_dump_name="mariadb.sql.gz"
+  mariadb_dump_path="$work_dir/$mariadb_dump_name"
+  ensure_mariadb_ready
+
+  printf "\nℹ️ Dumping MariaDB database …\n"
+  if ! docker exec "$mariadb_container" mysqldump -u root -pwordpressdb -A --add-drop-database |
+      gzip >"$mariadb_dump_path"; then
+    fail "Dumping MariaDB database failed. Please check the error above."
+  fi
+  if ! gzip -t -- "$mariadb_dump_path"; then
+    fail "MariaDB dump is corrupt or incomplete."
+  fi
+  printf "✅ MariaDB database dump done.\n"
+fi
+
 printf "\nℹ️ Stopping BTCPay Server …\n\n"
+btcpay_stopped=true
 btcpay_down
 
-printf "\n"
-cd $docker_dir
-echo "ℹ️ Archiving files in $(pwd)…"
+cd "$docker_dir"
+printf "\nℹ️ Archiving files in %s …\n" "$(pwd)"
 
-{
-  tar \
-    --exclude="volumes/backup_datadir" \
-    --exclude="volumes/generated_btcpay_datadir/_data/host_*" \
-    --exclude="volumes/generated_bitcoin_datadir/_data" \
-    --exclude="volumes/generated_litecoin_datadir/_data" \
-    --exclude="volumes/generated_mwebd_datadir" \
-    --exclude="volumes/generated_elements_datadir/_data" \
-    --exclude="volumes/generated_xmr_data/_data" \
-    --exclude="volumes/generated_bdx_data/_data" \
-    --exclude="volumes/generated_dogecoin_datadir/_data/blocks" \
-    --exclude="volumes/generated_dogecoin_datadir/_data/chainstate" \
-    --exclude="volumes/generated_dash_datadir/_data/blocks" \
-    --exclude="volumes/generated_dash_datadir/_data/chainstate" \
-    --exclude="volumes/generated_dash_datadir/_data/indexes" \
-    --exclude="volumes/generated_dash_datadir/_data/debug.log" \
-    --exclude="volumes/generated_dash_datadir/_data/evodb" \
-    --exclude="volumes/generated_mariadb_datadir" \
-    --exclude="volumes/generated_postgres_datadir" \
-    --exclude="volumes/generated_electrumx_datadir" \
-    --exclude="volumes/generated_lnd_bitcoin_datadir/_data/data/graph" \
-    --exclude="volumes/generated_clightning_bitcoin_datadir/_data/lightning-rpc" \
-    --exclude="volumes/generated_lwd-cache" \
-    --exclude="volumes/generated_zebrad-cache" \
-    --exclude="volumes/generated_zec_data" \
-    --exclude="**/logs/*" \
-    -cvzf $backup_path $postgres_dump_name  $mariadb_dump_name volumes/generated_*
-  echo "✅ Archive done."
+shopt -s nullglob
+volume_entries=(volumes/generated_*)
+shopt -u nullglob
+if [ "${#volume_entries[@]}" -eq 0 ]; then
+  fail "Could not find Docker volume directories to archive."
+fi
 
-  if [ ! -z "$BTCPAY_BACKUP_PASSPHRASE" ]; then
-    printf "\n"
-    echo "🔐 BTCPAY_BACKUP_PASSPHRASE is set, the backup will be encrypted."
-    {
-      gpg -o "$backup_path.gpg" --batch --yes -c --passphrase "$BTCPAY_BACKUP_PASSPHRASE" $backup_path
-      rm $backup_path
-      backup_path="$backup_path.gpg"
-      echo "✅ Encryption done."
-    } || {
-      echo "🚨  Encrypting failed. Please check the error message above."
-      printf "\nℹ️  Restarting BTCPay Server …\n\n"
-      cd $btcpay_dir
-      btcpay_up
-      exit 1
-    }
+dump_entries=("$postgres_dump_name")
+if [ -n "$mariadb_dump_name" ]; then
+  dump_entries+=("$mariadb_dump_name")
+fi
+
+tar_excludes=(
+  --exclude="volumes/backup_datadir"
+  --exclude="volumes/generated_btcpay_datadir/_data/host_*"
+  --exclude="volumes/generated_bitcoin_datadir/_data"
+  --exclude="volumes/generated_litecoin_datadir/_data"
+  --exclude="volumes/generated_mwebd_datadir"
+  --exclude="volumes/generated_elements_datadir/_data"
+  --exclude="volumes/generated_xmr_data/_data"
+  --exclude="volumes/generated_bdx_data/_data"
+  --exclude="volumes/generated_dogecoin_datadir/_data/blocks"
+  --exclude="volumes/generated_dogecoin_datadir/_data/chainstate"
+  --exclude="volumes/generated_dash_datadir/_data/blocks"
+  --exclude="volumes/generated_dash_datadir/_data/chainstate"
+  --exclude="volumes/generated_dash_datadir/_data/indexes"
+  --exclude="volumes/generated_dash_datadir/_data/debug.log"
+  --exclude="volumes/generated_dash_datadir/_data/evodb"
+  --exclude="volumes/generated_mariadb_datadir"
+  --exclude="volumes/generated_postgres_datadir"
+  --exclude="volumes/generated_electrumx_datadir"
+  --exclude="volumes/generated_lnd_bitcoin_datadir/_data/data/graph"
+  --exclude="volumes/generated_clightning_bitcoin_datadir/_data/lightning-rpc"
+  --exclude="volumes/generated_lwd-cache"
+  --exclude="volumes/generated_zebrad-cache"
+  --exclude="volumes/generated_zec_data"
+  --exclude="**/logs/*"
+)
+
+backup_filename=$(basename "$backup_path")
+if ! temporary_backup_path=$(mktemp "$backup_dir/.$backup_filename.XXXXXX"); then
+  fail "Could not create a temporary archive in $backup_dir."
+fi
+
+if [ -n "$backup_passphrase" ]; then
+  printf "\n🔐 BTCPAY_BACKUP_PASSPHRASE is set, the backup will be encrypted.\n"
+  if ! tar -czf - "${tar_excludes[@]}" \
+      -C "$work_dir" "${dump_entries[@]}" \
+      -C "$docker_dir" "${volume_entries[@]}" |
+      gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+        --symmetric --output "$temporary_backup_path" 3<<<"$backup_passphrase"; then
+    fail "Archiving or encrypting failed. Please check the error above."
   fi
-} || {
-  echo "🚨 Archiving failed. Please check the error message above."
-  printf "\nℹ️ Restarting BTCPay Server …\n\n"
-  cd $btcpay_dir
-  btcpay_up
-  exit 1
-}
+  if ! gpg --batch --quiet --yes --pinentry-mode loopback --passphrase-fd 3 \
+      --decrypt -- "$temporary_backup_path" 3<<<"$backup_passphrase" |
+      tar -tzf - >/dev/null; then
+    fail "Encrypted archive validation failed."
+  fi
+  printf "✅ Encrypted archive done.\n"
+else
+  if ! tar -czf "$temporary_backup_path" "${tar_excludes[@]}" \
+      -C "$work_dir" "${dump_entries[@]}" \
+      -C "$docker_dir" "${volume_entries[@]}"; then
+    fail "Archiving failed. Please check the error above."
+  fi
+  if ! tar -tzf "$temporary_backup_path" >/dev/null; then
+    fail "Archive validation failed."
+  fi
+  printf "✅ Archive done.\n"
+fi
+
+if ! mv -f -- "$temporary_backup_path" "$backup_path"; then
+  fail "Could not move the completed archive to $backup_path."
+fi
+temporary_backup_path=""
+
+if [ -n "$backup_passphrase" ] && { [ -e "$plain_backup_path" ] || [ -L "$plain_backup_path" ]; }; then
+  if ! rm -f -- "$plain_backup_path"; then
+    fail "Could not remove the unencrypted backup archive $plain_backup_path."
+  fi
+fi
 
 printf "\nℹ️ Restarting BTCPay Server …\n\n"
-cd $btcpay_dir
+cd "$btcpay_dir"
 btcpay_up
+btcpay_stopped=false
 
 printf "\nℹ️ Cleaning up …\n\n"
-rm $postgres_dump_path
+if ! cleanup_temporary_files; then
+  fail "Cleanup failed."
+fi
+postgres_dump_path=""
+mariadb_dump_path=""
+work_dir=""
 
-printf "✅ Backup done => $backup_path\n\n"
+printf "✅ Backup done => %s\n\n" "$backup_path"

--- a/btcpay-restore.sh
+++ b/btcpay-restore.sh
@@ -1,182 +1,358 @@
-#!/bin/bash -e
+#!/bin/bash
 
-set -o pipefail -o errexit
+set -Eeuo pipefail
 
-if [ "$(id -u)" != "0" ]; then
+# Restored files can contain database dumps and other secrets.
+umask 077
+
+restore_dir=""
+volumes_dir=""
+btcpay_stopped=false
+mariadb_dump_name=""
+postgres_container=""
+mariadb_container=""
+database_ready_timeout=""
+
+fail() {
+  printf "\n🚨 %s\n" "$1" >&2
+  exit 1
+}
+
+cleanup_on_exit() {
+  local status=$?
+
+  trap - EXIT
+
+  if [ "$status" -ne 0 ]; then
+    if [ "$btcpay_stopped" = true ] && [ -n "${BTCPAY_DOCKER_COMPOSE:-}" ]; then
+      printf "\nℹ️ Stopping containers after the failed restore …\n" >&2
+      if docker-compose -f "$BTCPAY_DOCKER_COMPOSE" down -t "${COMPOSE_HTTP_TIMEOUT:-180}" >/dev/null 2>&1; then
+        printf "ℹ️ BTCPay Server has been left stopped to avoid using partially restored data.\n" >&2
+      else
+        printf "⚠️ Containers could not be stopped automatically. Run btcpay-down.sh before continuing.\n" >&2
+      fi
+    fi
+
+    if [ -n "$restore_dir" ] && [ -d "$restore_dir" ]; then
+      printf "ℹ️ Restore files were retained in %s for diagnosis.\n" "$restore_dir" >&2
+    fi
+  fi
+
+  exit "$status"
+}
+
+wait_for_postgres() {
+  local container=$1
+  local elapsed
+
+  for ((elapsed = 0; elapsed < database_ready_timeout; elapsed++)); do
+    if docker exec "$container" pg_isready --quiet --username=postgres >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_mariadb() {
+  local container=$1
+  local elapsed
+
+  for ((elapsed = 0; elapsed < database_ready_timeout; elapsed++)); do
+    if docker exec "$container" mysqladmin --user=root --password=wordpressdb --silent ping >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+# pg_dumpall --clean emits cluster-level DROP commands without IF EXISTS in
+# older backups. It also tries to drop and recreate the bootstrap postgres role,
+# even though the restore is connected as that role. Normalize only those
+# pg_dumpall sections so all remaining SQL can safely use ON_ERROR_STOP.
+normalize_postgres_dump() {
+  awk '
+    /^-- Drop databases/ {
+      section = "drop_databases"
+      print
+      next
+    }
+    /^-- Drop tablespaces/ {
+      section = "drop_tablespaces"
+      print
+      next
+    }
+    /^-- Drop roles/ {
+      section = "drop_roles"
+      print
+      next
+    }
+    /^-- Roles[[:space:]]*$/ {
+      section = "roles"
+      print
+      next
+    }
+    /^-- [^-]/ {
+      section = ""
+      print
+      next
+    }
+
+    section == "drop_databases" && /^DROP DATABASE / {
+      if ($0 !~ /^DROP DATABASE IF EXISTS /) {
+        sub(/^DROP DATABASE /, "DROP DATABASE IF EXISTS ")
+      }
+      print
+      next
+    }
+    section == "drop_tablespaces" && /^DROP TABLESPACE / {
+      if ($0 !~ /^DROP TABLESPACE IF EXISTS /) {
+        sub(/^DROP TABLESPACE /, "DROP TABLESPACE IF EXISTS ")
+      }
+      print
+      next
+    }
+    section == "drop_roles" && /^DROP ROLE (IF EXISTS )?("postgres"|postgres);$/ {
+      next
+    }
+    section == "drop_roles" && /^DROP ROLE / {
+      if ($0 !~ /^DROP ROLE IF EXISTS /) {
+        sub(/^DROP ROLE /, "DROP ROLE IF EXISTS ")
+      }
+      print
+      next
+    }
+    section == "roles" && /^CREATE ROLE ("postgres"|postgres);$/ {
+      next
+    }
+
+    { print }
+  '
+}
+
+trap cleanup_on_exit EXIT
+
+if [ "$(id -u)" -ne 0 ]; then
   printf "\n🚨 This script must be run as root.\n"
-  printf "➡️ Use the command 'sudo su -' (include the trailing hypen) and try again.\n\n"
+  printf "➡️ Use the command 'sudo su -' (include the trailing hyphen) and try again.\n\n"
   exit 1
 fi
 
-backup_path=$1
+backup_path=${1:-}
 if [ -z "$backup_path" ]; then
   printf "\nℹ️ Usage: btcpay-restore.sh /path/to/backup.tar.gz\n\n"
   exit 1
 fi
 
 if [ ! -f "$backup_path" ]; then
-  printf "\n🚨 $backup_path does not exist.\n\n"
-  exit 1
+  fail "$backup_path does not exist."
 fi
 
-if [[ "$backup_path" == *.gpg && -z "$BTCPAY_BACKUP_PASSPHRASE" ]]; then
-  printf "\n🔐 $backup_path is encrypted. Please provide the passphrase to decrypt it."
+# Load the BTCPay environment when the caller has not already done so.
+if [[ "${OSTYPE:-}" == darwin* ]]; then
+  bash_profile_script="${HOME:?}/btcpay-env.sh"
+else
+  bash_profile_script="/etc/profile.d/btcpay-env.sh"
+fi
+if [ -f "$bash_profile_script" ]; then
+  # shellcheck source=/dev/null
+  . "$bash_profile_script"
+fi
+
+if [ -z "${BTCPAY_BASE_DIRECTORY:-}" ]; then
+  fail "BTCPAY_BASE_DIRECTORY is not set."
+fi
+if [ -z "${BTCPAY_DOCKER_COMPOSE:-}" ]; then
+  fail "BTCPAY_DOCKER_COMPOSE is not set."
+fi
+if [ -z "${BTCPAY_ENV_FILE:-}" ]; then
+  fail "BTCPAY_ENV_FILE is not set."
+fi
+database_ready_timeout="${BTCPAY_DATABASE_READY_TIMEOUT:-60}"
+if ! [[ "$database_ready_timeout" =~ ^[1-9][0-9]*$ ]]; then
+  fail "BTCPAY_DATABASE_READY_TIMEOUT must be a positive number of seconds."
+fi
+
+backup_passphrase="${BTCPAY_BACKUP_PASSPHRASE:-}"
+if [[ "$backup_path" == *.gpg && -z "$backup_passphrase" ]]; then
+  printf "\n🔐 %s is encrypted. Please provide the passphrase to decrypt it." "$backup_path"
   printf "\nℹ️ Usage: BTCPAY_BACKUP_PASSPHRASE=t0pSeCrEt btcpay-restore.sh /path/to/backup.tar.gz.gpg\n\n"
   exit 1
 fi
 
-# preparation
-docker_dir=$(docker volume inspect generated_btcpay_datadir --format="{{.Mountpoint}}" | sed -e "s%/volumes/.*%%g")
-restore_dir="$docker_dir/volumes/backup_datadir/_data/restore"
-postgres_dump_name=postgres.sql.gz
 btcpay_dir="$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
+postgres_dump_name="postgres.sql.gz"
 
-# ensure clean restore dir
-printf "\nℹ️ Cleaning restore directory $restore_dir …\n\n"
-rm -rf $restore_dir
-mkdir -p $restore_dir
+if [ ! -d "$btcpay_dir" ] || [ ! -f "$btcpay_dir/helpers.sh" ]; then
+  fail "BTCPay Server directory $btcpay_dir is missing or incomplete."
+fi
+if [ ! -f "$BTCPAY_DOCKER_COMPOSE" ]; then
+  fail "Docker Compose file $BTCPAY_DOCKER_COMPOSE does not exist."
+fi
+
+if ! btcpay_mountpoint=$(docker volume inspect generated_btcpay_datadir --format='{{.Mountpoint}}'); then
+  fail "Could not inspect the generated_btcpay_datadir Docker volume."
+fi
+if [ -z "$btcpay_mountpoint" ] || [ "$btcpay_mountpoint" = "/" ]; then
+  fail "Docker returned an unsafe BTCPay volume mountpoint."
+fi
+
+btcpay_volume_dir=$(dirname "$btcpay_mountpoint")
+if [ "$(basename "$btcpay_mountpoint")" != "_data" ] ||
+    [ "$(basename "$btcpay_volume_dir")" != "generated_btcpay_datadir" ]; then
+  fail "Docker returned an unexpected BTCPay volume mountpoint: $btcpay_mountpoint"
+fi
+
+volumes_dir=$(dirname "$btcpay_volume_dir")
+if [ -z "$volumes_dir" ] || [ "$volumes_dir" = "/" ] || [ "$volumes_dir" = "." ]; then
+  fail "Could not determine a safe Docker volumes directory."
+fi
+
+expected_restore_dir="$volumes_dir/backup_datadir/_data/restore"
+restore_dir="$expected_restore_dir"
+readonly expected_restore_dir
+
+printf "\nℹ️ Cleaning restore directory %s …\n\n" "$restore_dir"
+if ! rm -rf -- "$restore_dir"; then
+  fail "Could not clean restore directory $restore_dir."
+fi
+if ! mkdir -p -- "$restore_dir"; then
+  fail "Could not create restore directory $restore_dir."
+fi
 
 if [[ "$backup_path" == *.gpg ]]; then
-  echo "🔐 Decrypting backup file …"
-  {
-    gpg -o "${backup_path%.*}" --batch --yes --passphrase "$BTCPAY_BACKUP_PASSPHRASE" -d $backup_path
-    backup_path="${backup_path%.*}"
-    printf "✅ Decryption done.\n\n"
-  } || {
-    echo "🚨 Decryption failed. Please check the error message above."
-    exit 1
-  }
+  printf "🔐 Decrypting and extracting backup file …\n"
+  if ! gpg --batch --yes --pinentry-mode loopback --passphrase-fd 3 \
+      --decrypt -- "$backup_path" 3<<<"$backup_passphrase" |
+      tar -xzf - -C "$restore_dir"; then
+    fail "Decryption or archive extraction failed. Please check the error above."
+  fi
+  printf "✅ Decryption and extraction done.\n\n"
+else
+  printf "ℹ️ Extracting files in %s …\n" "$restore_dir"
+  if ! tar -xzf "$backup_path" -C "$restore_dir"; then
+    fail "Archive extraction failed. Please check the error above."
+  fi
+  printf "✅ Extraction done.\n\n"
 fi
 
-cd $restore_dir
+cd "$restore_dir"
 
-echo "ℹ️ Extracting files in $(pwd) …"
-tar -xvf $backup_path -C $restore_dir
-
-# basic control checks
 if [ ! -f "$postgres_dump_name" ]; then
-  printf "\n🚨 $postgres_dump_name does not exist.\n\n"
-  exit 1
+  fail "$postgres_dump_name does not exist in the backup."
 fi
-
 if [ ! -d "volumes" ]; then
-  printf "\n🚨 volumes directory does not exist.\n\n"
-  exit 1
+  fail "The volumes directory does not exist in the backup."
+fi
+if ! gzip -t -- "$postgres_dump_name"; then
+  fail "$postgres_dump_name is corrupt or incomplete."
 fi
 
 if [ -f "mariadb.sql.gz" ]; then
-  mariadb_dump_name=mariadb.sql.gz
+  mariadb_dump_name="mariadb.sql.gz"
+  if ! gzip -t -- "$mariadb_dump_name"; then
+    fail "$mariadb_dump_name is corrupt or incomplete."
+  fi
 fi
 
-cd $btcpay_dir
-. helpers.sh
+cd "$btcpay_dir"
+# shellcheck source=/dev/null
+. ./helpers.sh
 
 printf "\nℹ️ Stopping BTCPay Server …\n\n"
+btcpay_stopped=true
 btcpay_down
 
-cd $restore_dir
+cd "$restore_dir"
 
-{
-  printf "\nℹ️ Restoring volumes …\n"
-  # ensure volumes dir exists
-  if [ ! -d "$docker_dir/volumes" ]; then
-    mkdir -p $docker_dir/volumes
-  fi
-  # copy volume directories over
-  cp -r volumes/* $docker_dir/volumes/
-  # ensure datadirs excluded in backup exist
-  mkdir -p $docker_dir/volumes/generated_postgres_datadir/_data
-  if [ ! -z "$mariadb_dump_name" ]; then
-    mkdir -p $docker_dir/volumes/generated_mariadb_datadir/_data
-  fi
-  echo "✅ Volume restore done."
-} || {
-  echo "🚨  Restoring volumes failed. Please check the error message above."
-  printf "\nℹ️ Restarting BTCPay Server …\n\n"
-  cd $btcpay_dir
-  btcpay_up
-  exit 1
-}
+printf "\nℹ️ Restoring volumes …\n"
+if ! mkdir -p -- "$volumes_dir"; then
+  fail "Could not create Docker volumes directory $volumes_dir."
+fi
+# Overlay the backup so intentionally excluded blockchain data remains intact.
+shopt -s dotglob nullglob
+volume_entries=(volumes/*)
+shopt -u dotglob nullglob
+if [ "${#volume_entries[@]}" -eq 0 ]; then
+  fail "The backup does not contain any Docker volumes."
+fi
+if ! cp -a -- "${volume_entries[@]}" "$volumes_dir/"; then
+  fail "Restoring volumes failed. Please check the error above."
+fi
+if ! mkdir -p -- "$volumes_dir/generated_postgres_datadir/_data"; then
+  fail "Could not create the Postgres data directory."
+fi
+if [ -n "$mariadb_dump_name" ] &&
+    ! mkdir -p -- "$volumes_dir/generated_mariadb_datadir/_data"; then
+  fail "Could not create the MariaDB data directory."
+fi
+printf "✅ Volume restore done.\n"
 
-# Start Postgres database
-{
-  printf "\nℹ️ Starting Postgres database container …\n"
-  docker-compose -f $BTCPAY_DOCKER_COMPOSE up -d postgres
-  sleep 10
-  postgres_container=$(docker ps -a -q -f "name=postgres_1")
-  if [ -z "$postgres_container" ]; then
-    echo "🚨 Postgres database container could not be started or found."
-    printf "\nℹ️ Restarting BTCPay Server …\n\n"
-    cd $btcpay_dir
-    btcpay_up
-    exit 1
-  fi
-} || {
-  echo "🚨 Starting Postgres database container failed. Please check the error message above."
-  printf "\nℹ️ Restarting BTCPay Server …\n\n"
-  cd $btcpay_dir
-  btcpay_up
-  exit 1
-}
-
-# Optional: Start MariaDB database
-if [ ! -z "$mariadb_dump_name" ]; then
-  {
-    printf "\nℹ️ Starting MariaDB database container …\n"
-    docker-compose -f $BTCPAY_DOCKER_COMPOSE up -d mariadb
-    sleep 10
-    mariadb_container=$(docker ps -a -q -f "name=mariadb_1")
-    if [ -z "$mariadb_container" ]; then
-      echo "🚨 MariaDB database container could not be started or found."
-      printf "\nℹ️ Restarting BTCPay Server …\n\n"
-      cd $btcpay_dir
-      btcpay_up
-      exit 1
-    fi
-  } || {
-    echo "🚨 Starting MariaDB database container failed. Please check the error message above."
-    printf "\nℹ️ Restarting BTCPay Server …\n\n"
-    cd $btcpay_dir
-    btcpay_up
-    exit 1
-  }
+printf "\nℹ️ Starting Postgres database container …\n"
+if ! docker-compose -f "$BTCPAY_DOCKER_COMPOSE" up -d postgres; then
+  fail "Starting the Postgres database container failed."
+fi
+if ! postgres_container=$(docker-compose -f "$BTCPAY_DOCKER_COMPOSE" ps -q postgres); then
+  fail "The Postgres database container could not be found."
+fi
+if [ -z "$postgres_container" ] || [[ "$postgres_container" == *$'\n'* ]]; then
+  fail "Expected exactly one Postgres database container."
+fi
+if ! wait_for_postgres "$postgres_container"; then
+  fail "Postgres did not become ready within $database_ready_timeout seconds."
 fi
 
-cd $restore_dir
+if [ -n "$mariadb_dump_name" ]; then
+  printf "\nℹ️ Starting MariaDB database container …\n"
+  if ! docker-compose -f "$BTCPAY_DOCKER_COMPOSE" up -d mariadb; then
+    fail "Starting the MariaDB database container failed."
+  fi
+  if ! mariadb_container=$(docker-compose -f "$BTCPAY_DOCKER_COMPOSE" ps -q mariadb); then
+    fail "The MariaDB database container could not be found."
+  fi
+  if [ -z "$mariadb_container" ] || [[ "$mariadb_container" == *$'\n'* ]]; then
+    fail "Expected exactly one MariaDB database container."
+  fi
+  if ! wait_for_mariadb "$mariadb_container"; then
+    fail "MariaDB did not become ready within $database_ready_timeout seconds."
+  fi
+fi
 
-# Postgres database
-{
-  printf "\nℹ️ Restoring Postgres database …"
-  gunzip -c $postgres_dump_name | docker exec -i $postgres_container psql -U postgres postgres
-  echo "✅ Postgres database restore done."
-} || {
-  echo "🚨 Restoring Postgres database failed. Please check the error message above."
-  printf "\nℹ️  Restarting BTCPay Server …\n\n"
-  cd $btcpay_dir
-  btcpay_up
-  exit 1
-}
+cd "$restore_dir"
 
-# Optional: MariaDB database
-if [ ! -z "$mariadb_dump_name" ]; then
-  {
-    printf "\nℹ️ Restoring MariaDB database …"
-    gunzip -c $mariadb_dump_name | docker exec -i $mariadb_container mysql -u root -pwordpressdb
-    printf "\n✅ MariaDB database restore done."
-  } || {
-    echo "🚨 Restoring MariaDB database failed. Please check the error message above."
-    printf "\nℹ️  Restarting BTCPay Server …\n\n"
-    cd $btcpay_dir
-    btcpay_up
-    exit 1
-  }
+printf "\nℹ️ Restoring Postgres database …\n"
+if ! gzip -dc -- "$postgres_dump_name" |
+    normalize_postgres_dump |
+    docker exec -i "$postgres_container" \
+      psql -X --quiet --set=ON_ERROR_STOP=1 --username=postgres --dbname=postgres >/dev/null; then
+  fail "Restoring the Postgres database failed. Please check the error above."
+fi
+printf "✅ Postgres database restore done.\n"
+
+if [ -n "$mariadb_dump_name" ]; then
+  printf "\nℹ️ Restoring MariaDB database …\n"
+  if ! gzip -dc -- "$mariadb_dump_name" |
+      docker exec -i "$mariadb_container" \
+        mysql --user=root --password=wordpressdb >/dev/null; then
+    fail "Restoring the MariaDB database failed. Please check the error above."
+  fi
+  printf "✅ MariaDB database restore done.\n"
 fi
 
 printf "\nℹ️ Restarting BTCPay Server …\n\n"
-cd $btcpay_dir
+cd "$btcpay_dir"
 btcpay_up
+btcpay_stopped=false
 
 printf "\nℹ️ Cleaning up …\n\n"
-rm -rf $restore_dir
+if [ "$restore_dir" != "$expected_restore_dir" ] || [ -z "$restore_dir" ]; then
+  fail "Refusing to clean an unexpected restore directory."
+fi
+if ! rm -rf -- "$restore_dir"; then
+  fail "Could not clean restore directory $restore_dir."
+fi
 
 printf "✅ Restore done\n\n"

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,96 +1,96 @@
 # Backup & Restore
 
-This guide gets you up to speed with the [Docker deployment](https://docs.btcpayserver.org/Docker/)'s Backup & Restore process.
-You will learn about what to keep in mind when doing a backup and how to restore a backup.
+This guide explains the backup and restore process for the [Docker deployment](https://docs.btcpayserver.org/Docker/).
+You will learn what to consider when creating a backup and how to restore one.
 
 [[toc]]
 
 ## Remarks and Considerations
 
-The original backups strategy in BTCPay Server still exists and can be found [here](https://docs.btcpayserver.org/Docker/#how-can-i-back-up-my-btcpay-server).
-While this documentation covers the [new process](https://github.com/btcpayserver/btcpayserver-docker/pull/641), the old `backup.sh` script still works.
+The original backup strategy for BTCPay Server still exists and is documented [here](https://docs.btcpayserver.org/Docker/#how-can-i-back-up-my-btcpay-server).
+While this guide covers the [new process](https://github.com/btcpayserver/btcpayserver-docker/pull/641), the old `backup.sh` script still works.
 
 :::warning
-BTCPay Server is and will never be responsible for your backup.
-Please make sure the backup includes the files and data you want to store.
-Also, test the restore process before starting to rely on it.
+BTCPay Server is not and will never be responsible for your backups.
+Make sure your backups include all the files and data you want to preserve.
+Test that you can restore a backup before relying on your backup strategy.
 :::
 
 ### Lightning channel backup
 
-Please be aware of this important issue:
-Old Lightning channel state is toxic!
+Be aware of this important issue: old Lightning channel state is toxic!
 You can lose all your funds if you close a channel based on an outdated state — and the state changes often!
-If you publish an old state (say from yesterday's backup), you will most likely lose all your funds in the channel because the counterparty might publish a [revocation transaction](https://www.d11n.net/lightning-network-payment-channel-lifecycle.html#what-happens-in-case-of-a-false-close%3F)!
+If you publish an old state (for example, from yesterday's backup), you will most likely lose all your funds in the channel because the counterparty might publish a [revocation transaction](https://www.d11n.net/lightning-network-payment-channel-lifecycle.html#what-happens-in-case-of-a-false-close%3F)!
 
-There is a high chance of failure in a disaster recovery scenario, where you may do a backup once per night and need to restore that one backup.
+Disaster recovery is particularly risky if you back up only once per night and then need to restore that backup.
 
-The Lightning channel backup from the `btcpay-backup.sh` script will be sufficient in a migration case, where the shutdown of the old server happens cleanly.
-The old server should not be started after the restoration and start of the new server.
+The Lightning channel data captured by the `btcpay-backup.sh` script is sufficient for a planned migration, provided that the old server is shut down cleanly.
+Do not start the old server again after restoring and starting the new server.
 
 :::tip
-The Lightning static channel backup should be watched by a script and copied over to a remote server to ensure you always have the latest state available.
+The Lightning static channel backup should be monitored by a script and copied to a remote server so that you always have the latest state available.
 We will provide such a script with a future update.
-For now, keep the above in mind when restoring from the backup!
+Until then, keep the above in mind when restoring a backup!
 :::
 
 ## How does the backup work?
 
-The backup process is run with the `btcpay-backup.sh` script.
+The backup process is run using the `btcpay-backup.sh` script.
 
-Log in to your server, switch to the `root` user and type the following:
+Log in to your server, switch to the `root` user, and run the following commands:
 
 ```bash
 # The backup script needs to be run as the root user
 sudo su -
 
-# As the other scripts, it is inside the BTCPay base directory
-cd $BTCPAY_BASE_DIRECTORY/btcpayserver-docker
+# Like the other scripts, it is inside the BTCPay base directory
+cd "$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
 ./btcpay-backup.sh
 ```
 
-The backup process needs to be run as `root`.
-It will check for and let you know if you have to switch users.
+The backup script must be run as `root` and will tell you how to switch users if necessary.
 
-The script will do the following steps:
+The script performs the following steps:
 
-* Ensure the database container is running
-* Make a dump of the database
+* Ensure the database containers are running and ready
+* Dump the databases
 * Stop BTCPay Server
-* Archive the Docker volumes and database dump
-  * Excluding the blockchains `blocks` and `chainstate` directories
-  * Optional: [Encrypt the archive](#set-a-backup-passphrase)
+* Archive the Docker volumes and database dumps
+  * Exclude blockchain data and caches that can be downloaded again
+  * Optionally [encrypt the archive](#set-a-backup-passphrase)
 * Restart BTCPay Server
-* Cleanup: Remove temporary files like the database dump
+* Remove temporary files, such as the database dumps
 
-If the backup directory doesn't exist yet, the script will create it.
-With these preparations taken, the backup process is now starting.
+If the backup directory does not exist yet, the script creates it.
 
-The script has checks to ensure it either works or fails with a comprehensive error message at every step of the way.
-If there are errors, you will be notified like this:
+The script validates each step and stops with a clear error if one fails.
+For example:
 
 ```
-🚨 Database container could not be started or found.
+🚨 Postgres container could not be started or found.
 ```
 
-If everything works smoothly, you will see multiple completed marks in your console.
-Whenever the backup has completed successfully, it will state:
+If everything works smoothly, you will see several completion messages in your console.
+When an unencrypted backup completes successfully, the final message is:
 
 ```
 ✅ Backup done => /var/lib/docker/volumes/backup_datadir/_data/backup.tar.gz
 ```
 
-Your BTCPay Server has now finished the backup process.
-You must store these backups safely, for instance, by copying them to a remote server.
+When encryption is enabled, the output filename is `backup.tar.gz.gpg` instead.
 
-After making a backup the first time, it is always wise to at least test your backup in a restore scenario.
-We will go over the extra options you can set with your backup in the next topic.
+The backup is now complete.
+Store it safely, for instance, by copying it to a remote server.
+
+After creating your first backup, test it by restoring it in a safe environment.
+The next section explains how to enable backup encryption.
 
 ### Set a backup passphrase
 
-You can set the `BTCPAY_BACKUP_PASSPHRASE` environment variable for encrypting the backup.
-This passphrase will be used by the backup and restore scripts to encrypt and decrypt the backup file.
-For the backup script, this would look like the following:
+To encrypt a backup, set the `BTCPAY_BACKUP_PASSPHRASE` environment variable.
+The backup and restore scripts use this passphrase to encrypt and decrypt the backup file.
+The encrypted backup is saved as `backup.tar.gz.gpg`.
+For example:
 
 ```bash
 # Set the passphrase without adding it to the shell history
@@ -100,72 +100,80 @@ export BTCPAY_BACKUP_PASSPHRASE
 ./btcpay-backup.sh
 ```
 
-This `BTCPAY_BACKUP_PASSPHRASE` if set, is necessary to be in the [restore process](#how-to-restore) as well.
+To [restore](#how-to-restore) the encrypted backup, set `BTCPAY_BACKUP_PASSPHRASE` to the same passphrase.
 
 ### Automation by crontab
 
-Here is an example of a crontab script that does a nightly backup at 4:15 AM:
+Here is an example crontab entry that runs a nightly backup at 4:15 AM:
 
-```
+```bash
 SHELL=/bin/bash
 PATH=/bin:/usr/sbin:/usr/bin:/usr/local/bin
 15 4 * * * /root/BTCPayServer/btcpayserver-docker/btcpay-backup.sh >/dev/null 2>&1
 ```
 
-You need to set the right `SHELL` and `PATH`, so that the script can run with the correct context.
-You might also want to set the `BTCPAY_BACKUP_PASSPHRASE` environment variable.
+Set the correct `SHELL` and `PATH` so that the script runs in the expected environment.
+If the cron job should encrypt backups, also set `BTCPAY_BACKUP_PASSPHRASE` in its environment.
 
-Also ensure the base path (here `/root/BTCPayServer`) matches the output of `echo $BTCPAY_BASE_DIRECTORY`.
+Make sure the base path in the command (here `/root/BTCPayServer`) matches the output of `echo "$BTCPAY_BASE_DIRECTORY"`.
 
 ## How to restore?
 
-It's very similar to the `btcpay-backup.sh` process but in reverse.
-The `btcpay-restore.sh` script needs to be run with the path to your `backup.tar.gz` file.
+The restore process is similar to the `btcpay-backup.sh` process, but in reverse.
+Run the `btcpay-restore.sh` script with the full path to either an unencrypted `backup.tar.gz` file or an encrypted `backup.tar.gz.gpg` file.
 
-First off, open a terminal and type the following as root.
-Remember that if you set `BTCPAY_BACKUP_PASSPHRASE` on the backup, you also need to provide it for decryption :
+First, open a terminal and switch to the `root` user:
 
 ```bash
 # The restore script needs to be run as the root user
 sudo su -
 
-# As the other scripts, it is inside the BTCPay base directory
-cd $BTCPAY_BASE_DIRECTORY/btcpayserver-docker
+# Like the other scripts, it is inside the BTCPay base directory
+cd "$BTCPAY_BASE_DIRECTORY/btcpayserver-docker"
+```
 
-# Optional: Set the passphrase if you have used one for the backup
+To restore an unencrypted backup, run:
+
+```bash
+./btcpay-restore.sh /var/backups/backup.tar.gz
+```
+
+To restore an encrypted backup, set the same passphrase that was used to create it and run:
+
+```bash
 read -s -p "Enter passphrase: " BTCPAY_BACKUP_PASSPHRASE
 export BTCPAY_BACKUP_PASSPHRASE
 
-# Run the restore script with the full path to the backup file
 ./btcpay-restore.sh /var/backups/backup.tar.gz.gpg
 ```
 
 The script will do the following steps:
 
-* Extract (and decrypt) the backup archive
+* Extract the backup archive (and decrypt it when necessary)
 * Stop BTCPay Server
 * Restore the Docker volumes
 * Start the database containers and wait until they are ready
 * Import the database dumps with strict error handling
 * Restart BTCPay Server
-* Cleanup: Remove the temporary restore directory
+* Remove the temporary restore directory after a successful restore
 
-If the backup file cannot be found in the provided path, the script will exit with an error.
+If the backup file cannot be found at the provided path, the script exits with an error.
+For example:
 
 ```
 🚨 /var/backups/backup.tar.gz.gpg does not exist.
 ```
 
-Just as the `btcpay-backup.sh` script, the restore will stop at any error it encounters.
+Like the `btcpay-backup.sh` script, the restore script stops at any error it encounters.
 If an error occurs after BTCPay Server has been stopped, the containers remain stopped to avoid running against partially restored data.
 The temporary restore directory is retained for diagnosis and its path is printed in the error output.
-If the backup file was created while the `BTCPAY_BACKUP_PASSPHRASE` was set but not used on restoring, the following error would occur:
+If the passphrase for an encrypted backup is incorrect, the restore fails with the following error:
 
 ```
 🚨 Decryption or archive extraction failed. Please check the error above.
 ```
 
-When the restore has completed, you get the message:
+When the restore completes, you will see:
 
 ```
 ✅ Restore done
@@ -176,6 +184,6 @@ You've successfully restored your BTCPay Server. Congratulations!
 
 :::tip
 Always make sure your backup strategy is tested and fits your needs.
-No one solution fits all, and we tried to cover the basic cases.
-For the latest updates, always feel free to ask on the BTCPay Server community channels.
+No single solution fits every situation; this guide covers the common cases.
+For the latest guidance, feel free to ask on the BTCPay Server community channels.
 :::

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -145,8 +145,8 @@ The script will do the following steps:
 * Extract (and decrypt) the backup archive
 * Stop BTCPay Server
 * Restore the Docker volumes
-* Start the database container
-* Import the database dump
+* Start the database containers and wait until they are ready
+* Import the database dumps with strict error handling
 * Restart BTCPay Server
 * Cleanup: Remove the temporary restore directory
 
@@ -156,11 +156,13 @@ If the backup file cannot be found in the provided path, the script will exit wi
 🚨 /var/backups/backup.tar.gz.gpg does not exist.
 ```
 
-Just as the `btcpay-backup.sh` script, the restore will stop at ANY error it may encounter.
+Just as the `btcpay-backup.sh` script, the restore will stop at any error it encounters.
+If an error occurs after BTCPay Server has been stopped, the containers remain stopped to avoid running against partially restored data.
+The temporary restore directory is retained for diagnosis and its path is printed in the error output.
 If the backup file was created while the `BTCPAY_BACKUP_PASSPHRASE` was set but not used on restoring, the following error would occur:
 
 ```
-🚨  Decryption failed. Please check the error message above.
+🚨 Decryption or archive extraction failed. Please check the error above.
 ```
 
 When the restore has completed, you get the message:


### PR DESCRIPTION
I did run a full migration with those new scripts of a BTCPay instance with multiple plugins and fragments like woocommerce installed to ensure everything is working like before but nicer and with less confusing postgres commands displayed in stdout during restore.

**btcpay-backup.sh**
• Added strict mode, umask 077, validated env/config paths, and safer Docker volume path derivation.
• Replaced fragile docker ps name=... lookup with docker-compose ps -q.
• Added Postgres/MariaDB readiness polling with BTCPAY_DATABASE_READY_TIMEOUT.
• Writes dumps and archives through temp files, then atomically moves the completed backup into place so a failed backup does not clobber the last good archive.
• Encrypts by streaming tar into gpg with --passphrase-fd 3; no plaintext archive is written for encrypted backups and the passphrase is not passed as a process argument.
• Adds exit cleanup and restarts BTCPay automatically if a backup fails after shutdown.
• Cleans both Postgres and MariaDB temp dumps.
• Preserves the restore-compatible archive layout.

**btcpay-restore.sh**
• Added strict psql handling with ON_ERROR_STOP=1.
• Kept compatibility with old backups by normalizing missing IF EXISTS clauses and skipping only the expected bootstrap postgres drop/create statements.
• Replaced masked { … } || { … } error handling.
• Added PostgreSQL/MariaDB readiness polling with a configurable 60-second default.
• Failed restores now stop containers, leave BTCPay down, and retain diagnostic files.
• Volume copies preserve ownership and permissions without changing Docker’s parent directory metadata.
• Quoted paths and guarded destructive cleanup.
• Encrypted archives are streamed directly into tar; no plaintext archive is written, and the passphrase is no longer passed as a process argument.
• Removed noisy restore output and corrected message newlines.

**backup-restore.md**
• "Improve documentation, add separate examples for ecnrypted and unencrypted restores."
