### PR TITLE
Start mwebd before btcpayserver (and litecoind before mwebd)

### DIFF
--- a/docker-compose-generator/docker-fragments/opt-add-ltcmweb.yml
+++ b/docker-compose-generator/docker-fragments/opt-add-ltcmweb.yml
@@ -2,12 +2,16 @@ services:
   btcpayserver:
     environment:
       BTCPAY_LTC_MWEB_DAEMON_URI: http://mwebd:12345
+    depends_on:
+      - mwebd
   mwebd:
     restart: unless-stopped
     container_name: mwebd
     image: hectorchu1/mwebd
     volumes:
       - "mwebd_datadir:/data"
+    depends_on:
+      - litecoind
 volumes:
   mwebd_datadir:
 required:


### PR DESCRIPTION
On a cold 'docker compose down && up' (e.g. the nightly btcpay-backup.sh cron), all containers are recreated simultaneously. btcpayserver can reach plugin initialization before mwebd's gRPC port exists, which makes the LitecoinMweb plugin's startup fail with RpcException(Unavailable); BTCPay's crash protection then writes the plugin to the Plugins/disabled kill-list and it stays disabled until an admin re-enables it manually.

Declaring the startup order in the fragment closes that race: mwebd is a small Go daemon that binds its port in milliseconds, while btcpayserver takes several seconds to boot to the point of starting plugin hosted services.

See ltcmweb/btcpayserver-ltcmweb-plugin#3