### PR TITLE
Run RTL as an unprivileged user

### DIFF
--- a/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
+++ b/docker-compose-generator/docker-fragments/bitcoin-lnd.yml
@@ -44,10 +44,24 @@ services:
     links:
       - bitcoind
 
+  # RTL runs unprivileged (see below) but lnd_bitcoin_rtl_datadir may already be
+  # owned by root on instances created before that change, leaving RTL unable to
+  # write its config and SSO cookie. This one-shot container fixes ownership
+  # before RTL starts, mirroring bitcoin_thub_dircheck.
+  bitcoin_rtl_dircheck:
+    image: busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+    container_name: generated_lnd_bitcoin_rtl_dircheck
+    restart: "no"
+    command: ["sh", "-c", "chown -R 1000:0 /data"]
+    volumes:
+      - "lnd_bitcoin_rtl_datadir:/data"
   bitcoin_rtl:
     image: shahanafarooqui/rtl:v0.15.11
     container_name: generated_lnd_bitcoin_rtl_1
     restart: unless-stopped
+    depends_on:
+      - bitcoin_rtl_dircheck
+    user: "1000:0"
     environment:
       LND_SERVER_URL: http://lnd_bitcoin:8080/v1
       MACAROON_PATH: /etc/lnd
@@ -59,10 +73,10 @@ services:
       RTL_SSO: 1
       RTL_COOKIE_PATH: /data/.cookie
       LOGOUT_REDIRECT_LINK: /server/services
+      HOME: /data
     volumes:
       - "bitcoin_datadir:/etc/bitcoin"
       - "lnd_bitcoin_datadir:/etc/lnd"
-      - "lnd_bitcoin_datadir:/root/.lnd"
       - "lndloop_bitcoin_datadir:/etc/lndloop"
       - "lnd_bitcoin_rtl_datadir:/data"
     expose:


### PR DESCRIPTION
## Problem

`bitcoin_rtl` runs as root and mounts the whole LND data directory twice — at `/etc/lnd` and again at `/root/.lnd`. That gives RTL read access to files which have nothing to do with the macaroon it was configured with:

| file | mode |
| --- | --- |
| `data/chain/bitcoin/mainnet/wallet.db` | `600 root:root` |
| `data/chain/bitcoin/mainnet/walletunlock.json` | `644 root:root` |

`walletunlock.json` holds the wallet password in plaintext. A compromise of RTL is therefore equivalent to full control of the node wallet, no matter how restricted the macaroon handed to RTL is — and RTL is reachable from the internet through the nginx configuration shipped in this repository.

## Fix

Run RTL as `user: "1000:0"`.

The group is the part that makes this work, and it is worth spelling out. `admin.macaroon` is mode `640 root:root`, so gid 0 keeps it readable, while the wallet stays unreachable because `data/` is mode `700 root:root`. Both variants checked against a live mainnet datadir:

| user | admin.macaroon | tls.cert | wallet.db | walletunlock.json |
| --- | --- | --- | --- | --- |
| `1000:1000` | unreadable | readable | unreadable | unreadable |
| `1000:0` | readable | readable | unreadable | unreadable |

With `1000:1000` RTL cannot authenticate against LND at all, which is why the naive "just drop to uid 1000" version is not enough.

Two supporting changes:

- `HOME` moves to the data volume — `/root` in the image is mode 700, and RTL creates its backup directory under `HOME`;
- the `lnd_bitcoin_datadir:/root/.lnd` mount is dropped: it duplicated `/etc/lnd` and is meaningless for a non-root user.

## Existing instances

On instances created before this change `lnd_bitcoin_rtl_datadir` is owned by root, and RTL would no longer be able to write `RTL-Config.json` or its SSO cookie. A one-shot `bitcoin_rtl_dircheck` container fixes ownership before RTL starts — the same approach @apotdevin used for `bitcoin_thub_dircheck` in #1082, reusing the same pinned busybox digest.

## Testing

- `./build.sh` with `BTCPAYGEN_LIGHTNING=lnd` and `BTCPAYGEN_REVERSEPROXY=nginx` regenerates cleanly, and `docker compose config` validates the generated file.
- RTL has been running unprivileged (uid 1000) on a mainnet node here for three weeks — SSO login, channel management and backups all work. That deployment feeds the macaroon in by a different route, so the gid 0 part above is what makes the same setup work with the stock `MACAROON_PATH`.
