### PR TITLE
Do not let an update leave the server unreachable

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -258,6 +258,57 @@ btcpay_up() {
     cd "$(dirname "$BTCPAY_ENV_FILE")"
     docker-compose -f $BTCPAY_DOCKER_COMPOSE up --remove-orphans -d -t "${COMPOSE_HTTP_TIMEOUT:-180}"
     popd > /dev/null
+    ensure_reverse_proxy_up
+}
+
+# nginx can lose a race against the letsencrypt companion while the stack is
+# being recreated. The companion drops the certificate symlinks of every vhost
+# whose container is momentarily down, nginx then starts with a config that
+# still points at them and exits:
+#
+#   [emerg] cannot load certificate "/etc/nginx/certs/<host>.crt"
+#
+# Docker does not bring it back, because compose had stopped it on purpose
+# (hasBeenManuallyStopped), and the companion refuses to repair anything while
+# nginx is down ("nginx-proxy container nginx isn't running"). The deadlock
+# therefore outlives the update: compose reports success, every other container
+# is healthy, and the server answers nothing on ports 80/443 until a human
+# notices. By then docker-gen has already regenerated a config that falls back
+# to the default certificate, so starting nginx once more breaks the loop and
+# lets the companion restore the symlinks on its next run.
+ensure_reverse_proxy_up() {
+    [[ "$BTCPAYGEN_REVERSEPROXY" == "nginx" ]] || return 0
+    docker inspect nginx > /dev/null 2>&1 || return 0
+
+    local status
+    local i
+    # Give it a moment to settle, but do not sit through the whole grace period
+    # once it has already given up.
+    for i in $(seq 1 6); do
+        status="$(docker inspect -f '{{.State.Status}}' nginx 2>/dev/null)"
+        case "$status" in
+            running) return 0 ;;
+            exited|dead) break ;;
+        esac
+        sleep 5
+    done
+
+    echo "Warning: the nginx container is '$status' after the stack was brought up, starting it again..."
+    docker start nginx > /dev/null 2>&1
+    sleep 5
+
+    for i in $(seq 1 6); do
+        status="$(docker inspect -f '{{.State.Status}}' nginx 2>/dev/null)"
+        case "$status" in
+            running) echo "Info: nginx is running again."; return 0 ;;
+            exited|dead) break ;;
+        esac
+        sleep 5
+    done
+
+    echo "Error: nginx is '$status', this server will not answer on ports 80/443. Last lines of its log:"
+    docker logs --tail 10 nginx 2>&1 | sed 's/^/    /'
+    return 1
 }
 
 btcpay_pull() {


### PR DESCRIPTION
## What happened

A server updated from `Server Settings → Maintenance → Update` came back with every container healthy, an update that exited 0 — and nothing answering on ports 80/443. It stayed that way for 40 hours, until a human noticed.

The `nginx` container was `Exited (1)`:

```
[emerg] cannot load certificate "/etc/nginx/certs/<host>.crt":
        BIO_new_file() failed (No such file or directory)
```

The certificate itself was fine the whole time — valid, unexpired, covering the host. Only the symlink in `/etc/nginx/certs` was gone.

## Why it deadlocks

While the stack is recreated, the letsencrypt companion regenerates its domain list from the containers running *at that moment*. With `btcpayserver` momentarily down the list comes out empty:

```
18:11:12 Generated '/app/letsencrypt_service_data' from 7 containers
```

Every vhost is then considered disabled, and the companion removes the `.crt` / `.key` symlinks (`letsencrypt_service`, the "Remove disabled domains symlinks" loop — silent unless `DEBUG=1`, which is why nothing shows in the log). Seven seconds later nginx starts with the config docker-gen wrote just before that, still referencing the symlinks, and exits.

Nothing recovers after that:

- docker will not restart nginx — compose had stopped it deliberately: `ShouldRestart failed, container will not be restarted ... hasBeenManuallyStopped=true`;
- the companion will not repair anything while nginx is down: `Error: nginx-proxy container nginx isn't running`, once an hour, forever;
- docker-gen *has* meanwhile regenerated a perfectly good config that falls back to the default certificate — but nobody starts nginx to read it.

So the one thing that would fix it is the one thing that never happens.

## The change

`btcpay_up` runs `docker-compose up` and never checks the outcome. This adds `ensure_reverse_proxy_up`: if nginx is not running after the stack comes up, start it once (it then reads the regenerated config, and the companion restores the symlinks on its next run), and if that does not help, print its log and fail instead of reporting success.

It is a no-op unless `BTCPAYGEN_REVERSEPROXY=nginx` and an `nginx` container exists.

## Notes

- The symlink cleanup exists unchanged in acme-companion through **v2.8.2**, so bumping the companion image would not avoid this.
- Any event that briefly stops `btcpayserver` while the companion is up can trigger it — an update is just the most likely one.

## Testing

Exercised against real containers, five cases:

| case | result |
| --- | --- |
| `BTCPAYGEN_REVERSEPROXY=traefik` | returns immediately, does nothing |
| no `nginx` container at all | returns immediately, does nothing |
| nginx running | returns at once (0 s) |
| **nginx exited, restart works** | restarts it, `running` again, 6 s |
| nginx exited, restart does not help | prints the container log, returns 1 |
