### PR TITLE
Bump PostgreSQL to 18.6

### DIFF
--- a/docker-compose-generator/docker-fragments/postgres.yml
+++ b/docker-compose-generator/docker-fragments/postgres.yml
@@ -3,7 +3,7 @@ services:
     restart: unless-stopped
     container_name: generated_postgres_1
     shm_size: 256mb
-    image: btcpayserver/postgres:18.4
+    image: btcpayserver/postgres:18.6
     command: [ "-c", "random_page_cost=1.0", "-c", "shared_preload_libraries=pg_stat_statements" ]
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
## Summary

Updates PostgreSQL from 18.4 to 18.6.

## Compatibility

PostgreSQL 18.6 includes post-update actions for affected GIN statistics, `btree_gist` or extreme-length `ltree` indexes, and third-party logical decoding plugins. See the [PostgreSQL 18.6 release notes](https://www.postgresql.org/docs/18/release-18-6.html) for the applicable checks.